### PR TITLE
Add pratt parser

### DIFF
--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -3,40 +3,40 @@ import math
 struct vec2 {
     x: f64,
     y: f64
+
+    fn add(x: f64, y: f64): vec2 {
+        self.x *= x
+        self.y *= y
+        return self
+    }
+
+    fn sub(x: f64, y: f64): vec2 {
+        self.x *= x
+        self.y -= y
+        return self
+    }
+
+    fn norm(): vec2 {
+        let mag = self.magnitude()
+        if (mag != 0) {
+            self.x /= mag
+            self.y /= mag
+        }
+        return self
+    }
+
+    fn copy(): vec2 {
+        return new(self.x, self.y)
+    }
+
+    fn magnitude(): f64 {
+        return sqrt(self.x * self.x + self.y * self.y)
+    }
 }
 
-const pi: f64 = 3
+const ZERO: vec2 = new(0, 0)
 
 fn new(x: f64, y: f64): vec2 {
     let created = vec2 { x=x, y=y }
     return created
-}
-
-fn add(self: vec2, x: f64, y: f64): vec2 {
-    self.x *= x
-    self.y *= y
-    return self
-}
-
-fn sub(self: vec2, x: f64, y: f64): vec2 {
-    self.x *= x
-    self.y -= y
-    return self
-}
-
-fn norm(self: vec2): vec2 {
-    let mag = self.magnitude()
-    if (mag != 0) {
-        self.x /= mag
-        self.y /= mag
-    }
-    return self
-}
-
-fn copy(self: vec2): vec2 {
-    return new(self.x, self.y)
-}
-
-fn magnitude(self: vec2): f64 {
-    return sqrt(self.x * self.x + self.y * self.y)
 }

--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -7,8 +7,8 @@ struct vec2 {
 
 const pi: f64 = 3
 
-fn create(x: 64, y: f64): vec2 {
-    let created: vec2 = { x=x, y=y }
+fn new(x: f64, y: f64): vec2 {
+    let created = vec2 { x=x, y=y }
     return created
 }
 
@@ -22,4 +22,21 @@ fn sub(self: vec2, x: f64, y: f64): vec2 {
     self.x *= x
     self.y -= y
     return self
+}
+
+fn norm(self: vec2): vec2 {
+    let mag = self.magnitude()
+    if (mag != 0) {
+        self.x /= mag
+        self.y /= mag
+    }
+    return self
+}
+
+fn copy(self: vec2): vec2 {
+    return new(self.x, self.y)
+}
+
+fn magnitude(self: vec2): f64 {
+    return sqrt(self.x * self.x + self.y * self.y)
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -28,6 +28,11 @@ pub enum Expr {
         struct_name: Token,
         fields: Vec<(Token, Rc<Expr>)>,
     },
+    If {
+        condition: Rc<Expr>,
+        if_branch: Rc<Stmt>,
+        else_branch: Option<Rc<Stmt>>,
+    },
     Literal(Token),
     Variable(Token),
 }
@@ -36,11 +41,6 @@ pub enum Expr {
 pub enum Stmt {
     Block {
         statements: Vec<Rc<Stmt>>,
-    },
-    If {
-        condition: Expr,
-        if_branch: Rc<Stmt>,
-        else_branch: Option<Rc<Stmt>>,
     },
     Let {
         name: Token,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -69,6 +69,7 @@ pub enum Decl {
     Struct {
         name: Token,
         fields: Vec<(Token, Token)>,
+        methods: Vec<Rc<Decl>>,
     },
     Function {
         name: Token,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,87 @@
+use crate::lexer::Token;
+use std::rc::Rc;
+
+#[derive(Debug)]
+pub enum Expr {
+    Unary {
+        // -right
+        operator: Token,
+        right: Rc<Expr>,
+    },
+    Binary {
+        // left + right
+        left: Rc<Expr>,
+        operator: Token,
+        right: Rc<Expr>,
+    },
+    Set {
+        // object.name = right
+        object: Rc<Expr>,
+        name: String,
+        operator: Token,
+        right: Rc<Expr>,
+    },
+    Get {
+        // object.name
+        object: Rc<Expr>,
+        name: String,
+    },
+    Index {
+        // object[index]
+        object: Rc<Expr>,
+        index: Rc<Expr>,
+    },
+    Call {
+        // callee(..arguments)
+        callee: Rc<Expr>,
+        arguments: Vec<Rc<Expr>>,
+    },
+    Literal(Token),
+    Variable(String),
+}
+
+#[derive(Debug)]
+pub struct TypeDef {
+    var: String,
+    var_type: String,
+}
+
+#[derive(Debug)]
+pub enum Stmt {
+    Block {
+        statements: Vec<Rc<Stmt>>,
+    },
+    Struct {
+        name: String,
+        fields: Vec<TypeDef>,
+    },
+    Function {
+        name: String,
+        return_type: String,
+        params: Vec<TypeDef>,
+        body: Rc<Stmt>,
+    },
+    If {
+        condition: Expr,
+        if_branch: Rc<Stmt>,
+        else_branch: Option<Rc<Stmt>>,
+    },
+    Let {
+        name: String,
+        initializer: Expr,
+    },
+    Return {
+        value: Expr,
+    },
+    Break,
+    While {
+        condition: Expr,
+        body: Rc<Stmt>,
+    },
+    For {
+        initializer: Expr,
+        condition: Expr,
+        increment: Expr,
+        body: Rc<Stmt>,
+    },
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -14,18 +14,6 @@ pub enum Expr {
         operator: Token,
         right: Rc<Expr>,
     },
-    Set {
-        // object.name = right
-        object: Rc<Expr>,
-        name: String,
-        operator: Token,
-        right: Rc<Expr>,
-    },
-    Get {
-        // object.name
-        object: Rc<Expr>,
-        name: String,
-    },
     Index {
         // object[index]
         object: Rc<Expr>,
@@ -36,14 +24,12 @@ pub enum Expr {
         callee: Rc<Expr>,
         arguments: Vec<Rc<Expr>>,
     },
+    Create {
+        struct_name: Token,
+        fields: Vec<(Token, Rc<Expr>)>,
+    },
     Literal(Token),
-    Variable(String),
-}
-
-#[derive(Debug)]
-pub struct TypeDef {
-    var: String,
-    var_type: String,
+    Variable(Token),
 }
 
 #[derive(Debug)]
@@ -51,23 +37,13 @@ pub enum Stmt {
     Block {
         statements: Vec<Rc<Stmt>>,
     },
-    Struct {
-        name: String,
-        fields: Vec<TypeDef>,
-    },
-    Function {
-        name: String,
-        return_type: String,
-        params: Vec<TypeDef>,
-        body: Rc<Stmt>,
-    },
     If {
         condition: Expr,
         if_branch: Rc<Stmt>,
         else_branch: Option<Rc<Stmt>>,
     },
     Let {
-        name: String,
+        name: Token,
         initializer: Expr,
     },
     Return {
@@ -79,9 +55,30 @@ pub enum Stmt {
         body: Rc<Stmt>,
     },
     For {
-        initializer: Expr,
+        initializer: Rc<Stmt>,
         condition: Expr,
         increment: Expr,
         body: Rc<Stmt>,
+    },
+    Expr(Expr),
+}
+
+#[derive(Debug)]
+pub enum Decl {
+    Import(Token),
+    Struct {
+        name: Token,
+        fields: Vec<(Token, Token)>,
+    },
+    Function {
+        name: Token,
+        return_type: Token,
+        params: Vec<(Token, Token)>,
+        body: Stmt,
+    },
+    Const {
+        name: Token,
+        var_type: Token,
+        initializer: Expr,
     },
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -97,13 +97,6 @@ impl TokenType {
             _ => false,
         }
     }
-
-    pub fn is_variable(&self) -> bool {
-        match self {
-            Self::Identifier(_) | Self::VSelf => true,
-            _ => false,
-        }
-    }
 }
 
 pub struct Lexer<'a> {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,7 +1,8 @@
+use std::collections::VecDeque;
 use std::iter::Peekable;
 use std::str::Chars;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     token_type: TokenType,
     line: u32,
@@ -16,15 +17,21 @@ impl Token {
             column,
         }
     }
+
+    pub fn get_type(&self) -> &TokenType {
+        &self.token_type
+    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TokenType {
     // Brackets
-    ParenLeft,
-    ParenRight,
-    BraceLeft,
-    BraceRight,
+    ParenLeft,    // (
+    ParenRight,   // )
+    BraceLeft,    // {
+    BraceRight,   // }
+    BracketLeft,  // [
+    BracketRight, // ]
     Dot,
     Comma,
     Colon,
@@ -74,7 +81,7 @@ pub enum TokenType {
 
 pub struct Lexer<'a> {
     source: Peekable<Chars<'a>>,
-    tokens: Vec<Token>,
+    tokens: VecDeque<Token>,
     line: u32,
     column: u32,
 }
@@ -83,13 +90,13 @@ impl Lexer<'_> {
     pub fn new<'a>(source: Chars<'a>) -> Lexer<'a> {
         Lexer {
             source: source.peekable(),
-            tokens: vec![],
+            tokens: VecDeque::new(),
             line: 1,
             column: 0,
         }
     }
 
-    pub fn scan(mut self) -> Vec<Token> {
+    pub fn scan(mut self) -> VecDeque<Token> {
         while !self.is_at_end() {
             self.scan_token();
         }
@@ -104,6 +111,8 @@ impl Lexer<'_> {
                 ')' => self.add_token(TokenType::ParenRight),
                 '{' => self.add_token(TokenType::BraceLeft),
                 '}' => self.add_token(TokenType::BraceRight),
+                '[' => self.add_token(TokenType::BracketLeft),
+                ']' => self.add_token(TokenType::BracketRight),
                 ',' => self.add_token(TokenType::Comma),
                 '.' => self.add_token(TokenType::Dot),
                 ':' => self.add_token(TokenType::Colon),
@@ -243,7 +252,7 @@ impl Lexer<'_> {
 
     fn number(&mut self, c: char) {
         let mut text = String::from(c);
-        while Lexer::is_digit(*self.peek().unwrap()) {
+        while !self.is_at_end() && Lexer::is_digit(*self.peek().unwrap()) {
             match self.advance() {
                 Some(c) => {
                     text.push(c);
@@ -319,6 +328,6 @@ impl Lexer<'_> {
 
     fn add_token(&mut self, token_type: TokenType) {
         self.tokens
-            .push(Token::new(token_type, self.line, self.column))
+            .push_back(Token::new(token_type, self.line, self.column))
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -78,6 +78,7 @@ pub enum TokenType {
     Const,
     Return,
     Break,
+    VSelf,
 
     // Literal
     Bool(bool),
@@ -93,6 +94,13 @@ impl TokenType {
     pub fn is_identifer(&self) -> bool {
         match self {
             Self::Identifier(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_variable(&self) -> bool {
+        match self {
+            Self::Identifier(_) | Self::VSelf => true,
             _ => false,
         }
     }
@@ -263,6 +271,9 @@ impl Lexer<'_> {
             "while" => TokenType::While,
             "return" => TokenType::Return,
             "break" => TokenType::Break,
+            "self" => TokenType::VSelf,
+            "true" => TokenType::Bool(true),
+            "false" => TokenType::Bool(false),
             _ => TokenType::Identifier(text),
         };
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,8 +1,9 @@
 use std::collections::VecDeque;
+use std::convert::Into;
 use std::iter::Peekable;
 use std::str::Chars;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Token {
     token_type: TokenType,
     line: u32,
@@ -20,6 +21,12 @@ impl Token {
 
     pub fn get_type(&self) -> &TokenType {
         &self.token_type
+    }
+}
+
+impl Into<TokenType> for Token {
+    fn into(self) -> TokenType {
+        self.token_type
     }
 }
 
@@ -61,22 +68,34 @@ pub enum TokenType {
     Import,
     Function,
     Struct,
+    Enum,
     If,
     Else,
     While,
     For,
+    Match,
     Let,
     Const,
     Return,
     Break,
 
     // Literal
+    Bool(bool),
     Number(i32),
     String(String),
     Identifier(String),
 
     // Misc
     Eof,
+}
+
+impl TokenType {
+    pub fn is_identifer(&self) -> bool {
+        match self {
+            Self::Identifier(_) => true,
+            _ => false,
+        }
+    }
 }
 
 pub struct Lexer<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,54 @@
-mod lexer;
+use crate::{lexer::Lexer, parser::Parser};
+use std::{env, fs, io};
 
-use crate::lexer::Lexer;
-use std::fs;
+mod ast;
+mod lexer;
+mod parser;
 
 fn main() {
-    let content = fs::read_to_string("examples/vec2.tau").expect("Expected to open file");
-    let lexer = Lexer::new(content.chars());
-    print!("{:?}", lexer.scan());
+    let args: Vec<String> = env::args().collect();
+    match args.len() {
+        1 => {
+            let mut buffer = String::new();
+            while io::stdin().read_line(&mut buffer).is_ok() {
+                let lexer = Lexer::new(buffer.chars());
+                let tokens = lexer.scan();
+                if tokens.len() > 1 {
+                    let parser = Parser::new(tokens);
+                    println!("{:?}", parser.parse());
+                    buffer.clear();
+                } else {
+                    break;
+                }
+            }
+        }
+        2 => {
+            let content = fs::read_to_string(args.get(1).unwrap()).expect("Expected to open file");
+            let lexer = Lexer::new(content.chars());
+            let parser = Parser::new(lexer.scan());
+            println!("{:?}", parser.parse());
+        }
+        _ => println!("usage: {:?} [file]", args.first().unwrap()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{lexer::Lexer, parser::Parser};
+    use std::fs;
+
+    #[test]
+    fn lexer() {
+        let content = fs::read_to_string("examples/vec2.tau").expect("Expected to open file");
+        let lexer = Lexer::new(content.chars());
+        print!("{:?}", lexer.scan());
+    }
+
+    #[test]
+    fn scanner() {
+        let content = "(1+a[0]) * hypo(3, 4)";
+        let lexer = Lexer::new(content.chars());
+        let parser = Parser::new(lexer.scan());
+        println!("{:?}", parser.parse());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ fn main() {
                 let lexer = Lexer::new(buffer.chars());
                 let tokens = lexer.scan();
                 if tokens.len() > 1 {
-                    let parser = Parser::new(tokens);
-                    println!("{:?}", parser.parse());
+                    let mut parser = Parser::new(tokens);
+                    println!("{:#?}", parser.stmt());
                     buffer.clear();
                 } else {
                     break;
@@ -26,7 +26,7 @@ fn main() {
             let content = fs::read_to_string(args.get(1).unwrap()).expect("Expected to open file");
             let lexer = Lexer::new(content.chars());
             let parser = Parser::new(lexer.scan());
-            println!("{:?}", parser.parse());
+            println!("{:#?}", parser.parse());
         }
         _ => println!("usage: {:?} [file]", args.first().unwrap()),
     }
@@ -41,14 +41,22 @@ mod tests {
     fn lexer() {
         let content = fs::read_to_string("examples/vec2.tau").expect("Expected to open file");
         let lexer = Lexer::new(content.chars());
-        print!("{:?}", lexer.scan());
+        println!("{:?}", lexer.scan());
     }
 
     #[test]
-    fn scanner() {
+    fn parse_expr() {
         let content = "(1+a[0]) * hypo(3, 4)";
         let lexer = Lexer::new(content.chars());
-        let parser = Parser::new(lexer.scan());
-        println!("{:?}", parser.parse());
+        let mut parser = Parser::new(lexer.scan());
+        println!("{:?}", parser.expr());
+    }
+
+    #[test]
+    fn parse_stmt() {
+        let content = "{ let a = 1 if (a < 2) break }";
+        let lexer = Lexer::new(content.chars());
+        let mut parser = Parser::new(lexer.scan());
+        println!("{:?}", parser.stmt());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,7 +47,7 @@ impl Parser {
 
     fn decl_function(&mut self) -> Decl {
         let name = self.advance();
-        assert!(name.get_type().is_identifer());
+        assert!(name.get_type().is_identifer(), "{:?}", name);
         self.consume(&TokenType::ParenLeft);
         let mut params = Vec::new();
         while *self.peek().get_type() != TokenType::ParenRight {
@@ -59,7 +59,7 @@ impl Parser {
         self.consume(&TokenType::ParenRight);
         self.consume(&TokenType::Colon);
         let return_type = self.advance();
-        assert!(name.get_type().is_identifer());
+        assert!(name.get_type().is_identifer(), "{:?}", name);
         let body = self.stmt();
         Decl::Function {
             name,
@@ -73,15 +73,27 @@ impl Parser {
         let name = self.advance();
         assert!(name.get_type().is_identifer());
         self.consume(&TokenType::BraceLeft);
+
         let mut fields = Vec::new();
-        while *self.peek().get_type() != TokenType::BraceRight {
+        while self.peek().get_type().is_identifer() {
             fields.push(self.decl_type_def());
-            if *self.peek().get_type() != TokenType::BraceRight {
+            if *self.peek().get_type() == TokenType::Comma {
                 self.consume(&TokenType::Comma);
             }
         }
+
+        let mut methods = Vec::new();
+        while *self.peek().get_type() != TokenType::BraceRight {
+            self.consume(&TokenType::Function);
+            methods.push(Rc::new(self.decl_function()));
+        }
+
         self.consume(&TokenType::BraceRight);
-        Decl::Struct { name, fields }
+        Decl::Struct {
+            name,
+            fields,
+            methods,
+        }
     }
 
     fn decl_const(&mut self) -> Decl {
@@ -97,7 +109,7 @@ impl Parser {
 
     fn decl_type_def(&mut self) -> (Token, Token) {
         let name = self.advance();
-        assert!(name.get_type().is_variable(), "{:?}", name);
+        assert!(name.get_type().is_identifer(), "{:?}", name);
         self.consume(&TokenType::Colon);
         let type_name = self.advance();
         assert!(type_name.get_type().is_identifer(), "{:?}", type_name);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,155 @@
+use crate::{
+    ast::Expr,
+    lexer::{Token, TokenType},
+};
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+// Pratt parser inspired after the following block post:
+// https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
+pub struct Parser {
+    tokens: VecDeque<Token>,
+}
+
+impl Parser {
+    pub fn new(tokens: VecDeque<Token>) -> Parser {
+        Parser { tokens }
+    }
+
+    pub fn parse(mut self) -> Expr {
+        self.expr()
+    }
+
+    fn expr(&mut self) -> Expr {
+        self.expr_bp(0)
+    }
+
+    fn expr_bp(&mut self, min_bp: u8) -> Expr {
+        let next = self.tokens.pop_front().expect("Expected next token.");
+        let mut lhs = match next.get_type() {
+            TokenType::Number(_) | TokenType::String(_) => Expr::Literal(next),
+            TokenType::Identifier(name) => Expr::Variable(name.clone()),
+            TokenType::Add | TokenType::Sub | TokenType::Not => self.expr_unary(next),
+            TokenType::ParenLeft => self.expr_grouping(),
+            _ => todo!("{:?}", next.get_type()),
+        };
+
+        while self.has_next() {
+            let op = self.peek().get_type();
+            if let Some(l_bp) = Parser::postfix_binding_power(op) {
+                // If current binding power is below minimum, we return the left hand side expression
+                if l_bp < min_bp {
+                    break;
+                }
+                let next = self.tokens.pop_front().unwrap();
+                match next.get_type() {
+                    TokenType::BracketLeft => {
+                        lhs = self.expr_index(lhs);
+                    }
+                    TokenType::ParenLeft => {
+                        lhs = self.expr_call(lhs);
+                    }
+                    unexpected => unreachable!("Unexpected postfix operator: {:?}", unexpected),
+                }
+            } else if let Some((l_bp, r_bp)) = Parser::infix_binding_power(op) {
+                // If current binding power is below minimum, we return the left hand side expression
+                if l_bp < min_bp {
+                    break;
+                }
+                lhs = self.expr_binary(lhs, r_bp);
+            } else {
+                // We reached a token that is not an operator and stop
+                break;
+            }
+        }
+
+        lhs
+    }
+
+    fn expr_grouping(&mut self) -> Expr {
+        // Parse a new expression from the top
+        let lhs = self.expr();
+        // Consume the ending parenthesis
+        self.consume(&TokenType::ParenRight);
+        lhs
+    }
+
+    fn expr_index(&mut self, lhs: Expr) -> Expr {
+        let rhs = self.expr();
+        self.consume(&TokenType::BracketRight);
+        Expr::Index {
+            object: Rc::new(lhs),
+            index: Rc::new(rhs),
+        }
+    }
+
+    fn expr_call(&mut self, lhs: Expr) -> Expr {
+        let mut arguments = Vec::new();
+        while *self.peek().get_type() != TokenType::ParenRight {
+            arguments.push(Rc::new(self.expr()));
+            if *self.peek().get_type() == TokenType::Comma {
+                self.consume(&TokenType::Comma);
+            }
+        }
+        self.consume(&TokenType::ParenRight);
+        Expr::Call {
+            callee: Rc::new(lhs),
+            arguments,
+        }
+    }
+
+    fn expr_unary(&mut self, op: Token) -> Expr {
+        let r_bp = Parser::prefix_binding_power(op.get_type());
+        let rhs = self.expr_bp(r_bp);
+        Expr::Unary {
+            operator: op,
+            right: Rc::new(rhs),
+        }
+    }
+
+    fn expr_binary(&mut self, lhs: Expr, bp: u8) -> Expr {
+        let next = self.tokens.pop_front().unwrap();
+        let rhs = self.expr_bp(bp);
+        Expr::Binary {
+            left: Rc::new(lhs),
+            operator: next,
+            right: Rc::new(rhs),
+        }
+    }
+
+    fn prefix_binding_power(operator: &TokenType) -> u8 {
+        match operator {
+            TokenType::Add | TokenType::Sub => 6,
+            _ => panic!("Bad operator: {:?}", operator),
+        }
+    }
+
+    fn infix_binding_power(operator: &TokenType) -> Option<(u8, u8)> {
+        match operator {
+            TokenType::And | TokenType::Or | TokenType::Xor => Some((1, 2)),
+            TokenType::Add | TokenType::Sub => Some((2, 3)),
+            TokenType::Mul | TokenType::Div => Some((4, 5)),
+            TokenType::Dot => Some((8, 7)),
+            _ => None,
+        }
+    }
+
+    fn postfix_binding_power(operator: &TokenType) -> Option<u8> {
+        match operator {
+            TokenType::BracketLeft | TokenType::ParenLeft => Some(7),
+            _ => None,
+        }
+    }
+
+    fn consume(&mut self, expected: &TokenType) {
+        assert_eq!(self.tokens.pop_front().unwrap().get_type(), expected);
+    }
+
+    fn peek(&self) -> &Token {
+        self.tokens.front().unwrap()
+    }
+
+    fn has_next(&self) -> bool {
+        self.tokens.len() > 1
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::Expr,
+    ast::{Decl, Expr, Stmt},
     lexer::{Token, TokenType},
 };
 use std::collections::VecDeque;
@@ -9,29 +9,184 @@ use std::rc::Rc;
 // https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
 pub struct Parser {
     tokens: VecDeque<Token>,
+    declarations: Vec<Decl>,
 }
 
 impl Parser {
     pub fn new(tokens: VecDeque<Token>) -> Parser {
-        Parser { tokens }
+        Parser {
+            tokens,
+            declarations: Vec::new(),
+        }
     }
 
-    pub fn parse(mut self) -> Expr {
-        self.expr()
+    pub fn parse(mut self) -> Vec<Decl> {
+        while self.has_next() {
+            let declaration = self.decl();
+            self.declarations.push(declaration);
+        }
+        self.declarations
     }
 
-    fn expr(&mut self) -> Expr {
+    pub(crate) fn decl(&mut self) -> Decl {
+        let token = self.advance();
+        match token.get_type() {
+            TokenType::Import => self.decl_import(),
+            TokenType::Function => self.decl_function(),
+            TokenType::Struct => self.decl_struct(),
+            TokenType::Const => self.decl_const(),
+            _ => todo!("unimplemented decl: {:?}", token),
+        }
+    }
+
+    fn decl_import(&mut self) -> Decl {
+        let next = self.advance();
+        assert!(next.get_type().is_identifer());
+        Decl::Import(next)
+    }
+
+    fn decl_function(&mut self) -> Decl {
+        let name = self.advance();
+        assert!(name.get_type().is_identifer());
+        self.consume(&TokenType::ParenLeft);
+        let mut params = Vec::new();
+        while *self.peek().get_type() != TokenType::ParenRight {
+            params.push(self.decl_type_def());
+            if *self.peek().get_type() != TokenType::ParenRight {
+                self.consume(&TokenType::Comma);
+            }
+        }
+        self.consume(&TokenType::ParenRight);
+        self.consume(&TokenType::Colon);
+        let return_type = self.advance();
+        assert!(name.get_type().is_identifer());
+        let body = self.stmt();
+        Decl::Function {
+            name,
+            return_type,
+            params,
+            body,
+        }
+    }
+
+    fn decl_struct(&mut self) -> Decl {
+        let name = self.advance();
+        assert!(name.get_type().is_identifer());
+        self.consume(&TokenType::BraceLeft);
+        let mut fields = Vec::new();
+        while *self.peek().get_type() != TokenType::BraceRight {
+            fields.push(self.decl_type_def());
+            if *self.peek().get_type() != TokenType::BraceRight {
+                self.consume(&TokenType::Comma);
+            }
+        }
+        self.consume(&TokenType::BraceRight);
+        Decl::Struct { name, fields }
+    }
+
+    fn decl_const(&mut self) -> Decl {
+        let (name, var_type) = self.decl_type_def();
+        self.consume(&TokenType::Set);
+        let initializer = self.expr();
+        Decl::Const {
+            name,
+            var_type,
+            initializer,
+        }
+    }
+
+    fn decl_type_def(&mut self) -> (Token, Token) {
+        let name = self.advance();
+        assert!(name.get_type().is_identifer());
+        self.consume(&TokenType::Colon);
+        let type_name = self.advance();
+        assert!(type_name.get_type().is_identifer(), "{:?}", type_name);
+        (name, type_name)
+    }
+
+    pub(crate) fn stmt(&mut self) -> Stmt {
+        match self.peek().get_type() {
+            TokenType::BraceLeft => self.stmt_block(),
+            TokenType::If => self.stmt_if(),
+            TokenType::Let => self.stmt_let(),
+            TokenType::Return => {
+                self.advance();
+                Stmt::Return { value: self.expr() }
+            }
+            TokenType::Break => {
+                self.advance();
+                Stmt::Break
+            }
+            TokenType::While => self.stmt_while(),
+            _ => Stmt::Expr(self.expr()),
+        }
+    }
+
+    fn stmt_block(&mut self) -> Stmt {
+        self.advance();
+        let mut statements = Vec::new();
+        while *self.peek().get_type() != TokenType::BraceRight {
+            statements.push(Rc::new(self.stmt()));
+        }
+        self.consume(&TokenType::BraceRight);
+        Stmt::Block { statements }
+    }
+
+    fn stmt_if(&mut self) -> Stmt {
+        self.advance();
+        self.consume(&TokenType::ParenLeft);
+        let condition = self.expr();
+        self.consume(&TokenType::ParenRight);
+        let if_branch = Rc::new(self.stmt());
+        let else_branch = if *self.peek().get_type() == TokenType::Else {
+            self.consume(&TokenType::Else);
+            Some(Rc::new(self.stmt()))
+        } else {
+            None
+        };
+        Stmt::If {
+            condition,
+            if_branch,
+            else_branch,
+        }
+    }
+
+    fn stmt_let(&mut self) -> Stmt {
+        self.advance();
+        let name = self.advance();
+        assert!(name.get_type().is_identifer());
+        self.consume(&TokenType::Set);
+        let initializer = self.expr();
+        Stmt::Let { name, initializer }
+    }
+
+    fn stmt_while(&mut self) -> Stmt {
+        self.advance();
+        self.consume(&TokenType::ParenLeft);
+        let condition = self.expr();
+        self.consume(&TokenType::ParenRight);
+        let body = Rc::new(self.stmt());
+        Stmt::While { condition, body }
+    }
+
+    pub(crate) fn expr(&mut self) -> Expr {
         self.expr_bp(0)
     }
 
     fn expr_bp(&mut self, min_bp: u8) -> Expr {
-        let next = self.tokens.pop_front().expect("Expected next token.");
+        let next = self.advance();
         let mut lhs = match next.get_type() {
             TokenType::Number(_) | TokenType::String(_) => Expr::Literal(next),
-            TokenType::Identifier(name) => Expr::Variable(name.clone()),
+            TokenType::Identifier(_) => {
+                if *self.peek().get_type() == TokenType::BraceLeft {
+                    self.expr_create(next)
+                } else {
+                    Expr::Variable(next)
+                }
+            }
             TokenType::Add | TokenType::Sub | TokenType::Not => self.expr_unary(next),
             TokenType::ParenLeft => self.expr_grouping(),
-            _ => todo!("{:?}", next.get_type()),
+            _ => todo!("unexpected token in expression: {:?}", next),
         };
 
         while self.has_next() {
@@ -41,7 +196,7 @@ impl Parser {
                 if l_bp < min_bp {
                     break;
                 }
-                let next = self.tokens.pop_front().unwrap();
+                let next = self.advance();
                 match next.get_type() {
                     TokenType::BracketLeft => {
                         lhs = self.expr_index(lhs);
@@ -49,7 +204,7 @@ impl Parser {
                     TokenType::ParenLeft => {
                         lhs = self.expr_call(lhs);
                     }
-                    unexpected => unreachable!("Unexpected postfix operator: {:?}", unexpected),
+                    unexpected => unreachable!("Unexpected operator: {:?}", unexpected),
                 }
             } else if let Some((l_bp, r_bp)) = Parser::infix_binding_power(op) {
                 // If current binding power is below minimum, we return the left hand side expression
@@ -108,7 +263,7 @@ impl Parser {
     }
 
     fn expr_binary(&mut self, lhs: Expr, bp: u8) -> Expr {
-        let next = self.tokens.pop_front().unwrap();
+        let next = self.advance();
         let rhs = self.expr_bp(bp);
         Expr::Binary {
             left: Rc::new(lhs),
@@ -117,36 +272,74 @@ impl Parser {
         }
     }
 
+    fn expr_create(&mut self, struct_name: Token) -> Expr {
+        self.consume(&TokenType::BraceLeft);
+        let mut fields = Vec::new();
+        while *self.peek().get_type() != TokenType::BraceRight {
+            let name = self.advance();
+            assert!(name.get_type().is_identifer(), "{:?}", name);
+            self.consume(&TokenType::Set);
+            let expr = Rc::new(self.expr());
+            let field = (name, expr);
+            fields.push(field);
+            if *self.peek().get_type() != TokenType::BraceRight {
+                self.consume(&TokenType::Comma);
+            }
+        }
+        self.consume(&TokenType::BraceRight);
+        Expr::Create {
+            struct_name,
+            fields,
+        }
+    }
+
     fn prefix_binding_power(operator: &TokenType) -> u8 {
         match operator {
             TokenType::Add | TokenType::Sub => 6,
-            _ => panic!("Bad operator: {:?}", operator),
+            unexpected => unreachable!("Unexpected operator: {:?}", unexpected),
         }
     }
 
     fn infix_binding_power(operator: &TokenType) -> Option<(u8, u8)> {
         match operator {
-            TokenType::And | TokenType::Or | TokenType::Xor => Some((1, 2)),
-            TokenType::Add | TokenType::Sub => Some((2, 3)),
-            TokenType::Mul | TokenType::Div => Some((4, 5)),
-            TokenType::Dot => Some((8, 7)),
+            TokenType::Set
+            | TokenType::SetAdd
+            | TokenType::SetSub
+            | TokenType::SetMul
+            | TokenType::SetDiv => Some((1, 2)),
+            TokenType::Low
+            | TokenType::Leq
+            | TokenType::Eq
+            | TokenType::Gre
+            | TokenType::Geq
+            | TokenType::Neq => Some((3, 4)),
+            TokenType::And | TokenType::Or | TokenType::Xor => Some((5, 6)),
+            TokenType::Add | TokenType::Sub => Some((7, 8)),
+            TokenType::Mul | TokenType::Div => Some((9, 10)),
+            TokenType::Dot => Some((12, 11)),
             _ => None,
         }
     }
 
     fn postfix_binding_power(operator: &TokenType) -> Option<u8> {
         match operator {
-            TokenType::BracketLeft | TokenType::ParenLeft => Some(7),
+            TokenType::BracketLeft | TokenType::ParenLeft | TokenType::Not => Some(11),
             _ => None,
         }
     }
 
-    fn consume(&mut self, expected: &TokenType) {
-        assert_eq!(self.tokens.pop_front().unwrap().get_type(), expected);
+    fn consume(&mut self, expected: &TokenType) -> Token {
+        let next = self.advance();
+        assert_eq!(next.get_type(), expected, "{:?}", next);
+        next
+    }
+
+    fn advance(&mut self) -> Token {
+        self.tokens.pop_front().expect("Expected next token")
     }
 
     fn peek(&self) -> &Token {
-        self.tokens.front().unwrap()
+        self.tokens.front().expect("Expected next token")
     }
 
     fn has_next(&self) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -97,7 +97,7 @@ impl Parser {
 
     fn decl_type_def(&mut self) -> (Token, Token) {
         let name = self.advance();
-        assert!(name.get_type().is_identifer());
+        assert!(name.get_type().is_variable(), "{:?}", name);
         self.consume(&TokenType::Colon);
         let type_name = self.advance();
         assert!(type_name.get_type().is_identifer(), "{:?}", type_name);
@@ -107,7 +107,6 @@ impl Parser {
     pub(crate) fn stmt(&mut self) -> Stmt {
         match self.peek().get_type() {
             TokenType::BraceLeft => self.stmt_block(),
-            TokenType::If => self.stmt_if(),
             TokenType::Let => self.stmt_let(),
             TokenType::Return => {
                 self.advance();
@@ -130,25 +129,6 @@ impl Parser {
         }
         self.consume(&TokenType::BraceRight);
         Stmt::Block { statements }
-    }
-
-    fn stmt_if(&mut self) -> Stmt {
-        self.advance();
-        self.consume(&TokenType::ParenLeft);
-        let condition = self.expr();
-        self.consume(&TokenType::ParenRight);
-        let if_branch = Rc::new(self.stmt());
-        let else_branch = if *self.peek().get_type() == TokenType::Else {
-            self.consume(&TokenType::Else);
-            Some(Rc::new(self.stmt()))
-        } else {
-            None
-        };
-        Stmt::If {
-            condition,
-            if_branch,
-            else_branch,
-        }
     }
 
     fn stmt_let(&mut self) -> Stmt {
@@ -176,7 +156,7 @@ impl Parser {
     fn expr_bp(&mut self, min_bp: u8) -> Expr {
         let next = self.advance();
         let mut lhs = match next.get_type() {
-            TokenType::Number(_) | TokenType::String(_) => Expr::Literal(next),
+            TokenType::Bool(_) | TokenType::Number(_) | TokenType::String(_) => Expr::Literal(next),
             TokenType::Identifier(_) => {
                 if *self.peek().get_type() == TokenType::BraceLeft {
                     self.expr_create(next)
@@ -184,8 +164,10 @@ impl Parser {
                     Expr::Variable(next)
                 }
             }
+            TokenType::VSelf => Expr::Variable(next),
             TokenType::Add | TokenType::Sub | TokenType::Not => self.expr_unary(next),
             TokenType::ParenLeft => self.expr_grouping(),
+            TokenType::If => self.expr_if(),
             _ => todo!("unexpected token in expression: {:?}", next),
         };
 
@@ -293,6 +275,24 @@ impl Parser {
         }
     }
 
+    fn expr_if(&mut self) -> Expr {
+        self.consume(&TokenType::ParenLeft);
+        let condition = Rc::new(self.expr());
+        self.consume(&TokenType::ParenRight);
+        let if_branch = Rc::new(self.stmt());
+        let else_branch = if *self.peek().get_type() == TokenType::Else {
+            self.consume(&TokenType::Else);
+            Some(Rc::new(self.stmt()))
+        } else {
+            None
+        };
+        Expr::If {
+            condition,
+            if_branch,
+            else_branch,
+        }
+    }
+
     fn prefix_binding_power(operator: &TokenType) -> u8 {
         match operator {
             TokenType::Add | TokenType::Sub => 6,
@@ -307,13 +307,13 @@ impl Parser {
             | TokenType::SetSub
             | TokenType::SetMul
             | TokenType::SetDiv => Some((1, 2)),
+            TokenType::And | TokenType::Or | TokenType::Xor => Some((3, 4)),
             TokenType::Low
             | TokenType::Leq
             | TokenType::Eq
             | TokenType::Gre
             | TokenType::Geq
-            | TokenType::Neq => Some((3, 4)),
-            TokenType::And | TokenType::Or | TokenType::Xor => Some((5, 6)),
+            | TokenType::Neq => Some((5, 6)),
             TokenType::Add | TokenType::Sub => Some((7, 8)),
             TokenType::Mul | TokenType::Div => Some((9, 10)),
             TokenType::Dot => Some((12, 11)),


### PR DESCRIPTION
The pratt parser currently support the following features:
- declaration
    - import
    - struct
    - function
    - constant
- statement
    - block
    - if & else
    - let
    - return
    - break
    - while loops
    - expression as a statement
- expression
    - unary
    - binary
    - index
    - function call
    - struct creation
    - literal (only integer and string)
    - variable

The following features are still missing:
- floats
- boolean
- for loops
- enums
- generics

I think that on the long term the implementation of a trait system would be useful for a better usage of the static type system.