### PR TITLE
Create headers and resolution

### DIFF
--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -1,5 +1,11 @@
 import math
 
+fn sqrt(v: f64): f64 {
+    // We need this dummy function because imports
+    // are currently not supported
+    return v
+}
+
 struct vec2 {
     x: f64,
     y: f64

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -15,6 +15,10 @@ pub enum Expr {
         operator: Token,
         right: Rc<Expr>,
     },
+    Get {
+        left: Rc<Expr>,
+        right: Token,
+    },
     Index {
         // object[index]
         object: Rc<Expr>,
@@ -47,6 +51,7 @@ pub trait ExprVisitor<'a, T> {
                 operator,
                 right,
             } => self.visit_binary(left, operator, right),
+            Expr::Get { left, right } => self.visit_get(left, right),
             Expr::Index { object, index } => self.visit_index(object, index),
             Expr::Call { callee, arguments } => self.visit_call(callee, arguments),
             Expr::Create {
@@ -66,6 +71,8 @@ pub trait ExprVisitor<'a, T> {
     fn visit_unary(&mut self, operator: &'a Token, right: &'a Rc<Expr>) -> T;
 
     fn visit_binary(&mut self, left: &'a Rc<Expr>, operator: &'a Token, right: &'a Rc<Expr>) -> T;
+
+    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Token) -> T;
 
     fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> T;
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -76,9 +76,9 @@ pub trait ExprVisitor<'a, T> {
 
     fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> T;
 
-    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a Vec<Rc<Expr>>) -> T;
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> T;
 
-    fn visit_create(&mut self, struct_name: &'a Token, fields: &'a Vec<(Token, Rc<Expr>)>) -> T;
+    fn visit_create(&mut self, struct_name: &'a Token, fields: &'a [(Token, Rc<Expr>)]) -> T;
 
     fn visit_if(
         &mut self,
@@ -137,7 +137,7 @@ pub trait StmtVisitor<'a, T> {
         }
     }
 
-    fn visit_block(&mut self, statements: &'a Vec<Rc<Stmt>>) -> T;
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> T;
 
     fn visit_let(&mut self, name: &'a Token, initializer: &'a Expr) -> T;
 
@@ -208,15 +208,15 @@ pub trait DeclVisitor<'a, T> {
     fn visit_struct(
         &mut self,
         name: &'a Token,
-        fields: &'a Vec<(Token, Token)>,
-        methods: &'a Vec<Rc<Decl>>,
+        fields: &'a [(Token, Token)],
+        methods: &'a [Rc<Decl>],
     ) -> T;
 
     fn visit_function(
         &mut self,
         name: &'a Token,
         return_type: &'a Token,
-        params: &'a Vec<(Token, Token)>,
+        params: &'a [(Token, Token)],
         body: &'a Stmt,
     ) -> T;
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,6 +38,53 @@ pub enum Expr {
     Variable(Token),
 }
 
+pub trait ExprVisitor<'a, T> {
+    fn visit_expr(&mut self, expr: &'a Expr) -> T {
+        match expr {
+            Expr::Unary { operator, right } => self.visit_unary(operator, right),
+            Expr::Binary {
+                left,
+                operator,
+                right,
+            } => self.visit_binary(left, operator, right),
+            Expr::Index { object, index } => self.visit_index(object, index),
+            Expr::Call { callee, arguments } => self.visit_call(callee, arguments),
+            Expr::Create {
+                struct_name,
+                fields,
+            } => self.visit_create(struct_name, fields),
+            Expr::If {
+                condition,
+                if_branch,
+                else_branch,
+            } => self.visit_if(condition, if_branch, else_branch),
+            Expr::Literal(value) => self.visit_literal(value),
+            Expr::Variable(name) => self.visit_variable(name),
+        }
+    }
+
+    fn visit_unary(&mut self, operator: &'a Token, right: &'a Rc<Expr>) -> T;
+
+    fn visit_binary(&mut self, left: &'a Rc<Expr>, operator: &'a Token, right: &'a Rc<Expr>) -> T;
+
+    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> T;
+
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a Vec<Rc<Expr>>) -> T;
+
+    fn visit_create(&mut self, struct_name: &'a Token, fields: &'a Vec<(Token, Rc<Expr>)>) -> T;
+
+    fn visit_if(
+        &mut self,
+        condition: &'a Rc<Expr>,
+        if_branch: &'a Rc<Stmt>,
+        else_branch: &'a Option<Rc<Stmt>>,
+    ) -> T;
+
+    fn visit_literal(&mut self, value: &'a Token) -> T;
+
+    fn visit_variable(&mut self, name: &'a Token) -> T;
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum Stmt {
@@ -62,7 +109,46 @@ pub enum Stmt {
         increment: Expr,
         body: Rc<Stmt>,
     },
-    Expr(Expr),
+    ExprStmt(Expr),
+}
+
+pub trait StmtVisitor<'a, T> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) -> T {
+        match stmt {
+            Stmt::Block { statements } => self.visit_block(statements),
+            Stmt::Let { name, initializer } => self.visit_let(name, initializer),
+            Stmt::Return { value } => self.visit_return(value),
+            Stmt::Break => self.visit_break(),
+            Stmt::While { condition, body } => self.visit_while(condition, body),
+            Stmt::For {
+                initializer,
+                condition,
+                increment,
+                body,
+            } => self.visit_for(initializer, condition, increment, body),
+            Stmt::ExprStmt(expr) => self.visit_expr_stmt(expr),
+        }
+    }
+
+    fn visit_block(&mut self, statements: &'a Vec<Rc<Stmt>>) -> T;
+
+    fn visit_let(&mut self, name: &'a Token, initializer: &'a Expr) -> T;
+
+    fn visit_return(&mut self, value: &'a Expr) -> T;
+
+    fn visit_break(&mut self) -> T;
+
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> T;
+
+    fn visit_for(
+        &mut self,
+        initializer: &'a Rc<Stmt>,
+        condition: &'a Expr,
+        increment: &'a Expr,
+        body: &'a Rc<Stmt>,
+    ) -> T;
+
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> T;
 }
 
 #[derive(Debug)]
@@ -85,4 +171,47 @@ pub enum Decl {
         var_type: Token,
         initializer: Expr,
     },
+}
+
+pub trait DeclVisitor<'a, T> {
+    fn visit_decl(&mut self, decl: &'a Decl) -> T {
+        match decl {
+            Decl::Import(name) => self.visit_import(name),
+            Decl::Struct {
+                name,
+                fields,
+                methods,
+            } => self.visit_struct(name, fields, methods),
+            Decl::Function {
+                name,
+                return_type,
+                params,
+                body,
+            } => self.visit_function(name, return_type, params, body),
+            Decl::Const {
+                name,
+                var_type,
+                initializer,
+            } => self.visit_const(name, var_type, initializer),
+        }
+    }
+
+    fn visit_import(&mut self, name: &'a Token) -> T;
+
+    fn visit_struct(
+        &mut self,
+        name: &'a Token,
+        fields: &'a Vec<(Token, Token)>,
+        methods: &'a Vec<Rc<Decl>>,
+    ) -> T;
+
+    fn visit_function(
+        &mut self,
+        name: &'a Token,
+        return_type: &'a Token,
+        params: &'a Vec<(Token, Token)>,
+        body: &'a Stmt,
+    ) -> T;
+
+    fn visit_const(&mut self, name: &'a Token, var_type: &'a Token, initializer: &'a Expr) -> T;
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,22 +1,22 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use crate::ast::{Decl, DeclVisitor, Expr, Stmt};
 use crate::lexer::Token;
-use crate::ast::{Decl, DeclVisitor, Stmt, Expr};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeDef<'a> {
     Struct {
         name: &'a str,
-        members: HashMap<&'a str, Rc<TypeDef<'a>>>
+        members: HashMap<&'a str, Rc<TypeDef<'a>>>,
     },
     Function {
         name: &'a str,
         parameters: HashMap<&'a str, Rc<TypeDef<'a>>>,
-        return_type: Rc<TypeDef<'a>>
+        return_type: Rc<TypeDef<'a>>,
     },
     Native(&'static str),
-    Lazy(&'a str)
+    Lazy(&'a str),
 }
 
 impl TypeDef<'_> {
@@ -24,7 +24,7 @@ impl TypeDef<'_> {
         if let TypeDef::Native(type_name) = *self {
             match type_name {
                 "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" => true,
-                _ => false   
+                _ => false,
             }
         } else {
             false
@@ -35,7 +35,7 @@ impl TypeDef<'_> {
         if let TypeDef::Native(type_name) = *self {
             match type_name {
                 "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64" => true,
-                _ => false   
+                _ => false,
             }
         } else {
             false
@@ -73,9 +73,9 @@ impl<'a> Header<'a> {
                 ("bool", Rc::new(TypeDef::Native("bool"))),
                 ("char", Rc::new(TypeDef::Native("char"))),
                 ("str", Rc::new(TypeDef::Native("str"))),
-                ("void", Rc::new(TypeDef:: Native("void")))
+                ("void", Rc::new(TypeDef::Native("void"))),
             ]),
-            fields: HashMap::new()
+            fields: HashMap::new(),
         }
     }
 
@@ -86,16 +86,30 @@ impl<'a> Header<'a> {
         self
     }
 
-    pub fn analysed(self) -> (HashMap<&'a str, Rc<TypeDef<'a>>>, HashMap<&'a str, Rc<TypeDef<'a>>>) {
+    pub fn analysed(
+        self,
+    ) -> (
+        HashMap<&'a str, Rc<TypeDef<'a>>>,
+        HashMap<&'a str, Rc<TypeDef<'a>>>,
+    ) {
         (self.types, self.fields)
     }
 
-    fn make_function(&self, name: &'a Token, return_type: &'a Token, params: &'a Vec<(Token, Token)>) -> Rc<TypeDef<'a>> {
+    fn make_function(
+        &self,
+        name: &'a Token,
+        return_type: &'a Token,
+        params: &'a Vec<(Token, Token)>,
+    ) -> Rc<TypeDef<'a>> {
         let mut parameters = HashMap::new();
         for (param_name, param_type) in params {
             parameters.insert(param_name.identifier(), self.get_type(param_type));
         }
-        Rc::new(TypeDef::Function { name: name.identifier(), parameters, return_type: self.get_type(return_type) })
+        Rc::new(TypeDef::Function {
+            name: name.identifier(),
+            parameters,
+            return_type: self.get_type(return_type),
+        })
     }
 
     fn get_type(&self, name: &'a Token) -> Rc<TypeDef<'a>> {
@@ -105,7 +119,6 @@ impl<'a> Header<'a> {
         } else {
             Rc::new(TypeDef::Lazy(ref_name))
         }
-        
     }
 }
 
@@ -127,12 +140,27 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
             members.insert(field_name.identifier(), self.get_type(field_type));
         }
         for decl in methods {
-            if let Decl::Function { name, return_type, params, .. } = &**decl {
-                members.insert(name.identifier(), self.make_function(name, return_type, params));
+            if let Decl::Function {
+                name,
+                return_type,
+                params,
+                ..
+            } = &**decl
+            {
+                members.insert(
+                    name.identifier(),
+                    self.make_function(name, return_type, params),
+                );
             }
         }
 
-        self.types.insert(struct_name, Rc::new(TypeDef::Struct { name: struct_name, members }));
+        self.types.insert(
+            struct_name,
+            Rc::new(TypeDef::Struct {
+                name: struct_name,
+                members,
+            }),
+        );
     }
 
     fn visit_function(
@@ -142,10 +170,14 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
         params: &'a Vec<(Token, Token)>,
         _: &Stmt,
     ) {
-        self.fields.insert(name.identifier(), self.make_function(name, return_type, params));
+        self.fields.insert(
+            name.identifier(),
+            self.make_function(name, return_type, params),
+        );
     }
 
     fn visit_const(&mut self, name: &'a Token, var_type: &'a Token, _: &Expr) {
-        self.fields.insert(name.identifier(), self.get_type(var_type));
+        self.fields
+            .insert(name.identifier(), self.get_type(var_type));
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -22,24 +22,22 @@ pub enum TypeDef<'a> {
 impl TypeDef<'_> {
     pub fn is_integer(&self) -> bool {
         if let TypeDef::Native(type_name) = *self {
-            match type_name {
-                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" => true,
-                _ => false,
-            }
-        } else {
-            false
+            return matches!(
+                type_name,
+                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64"
+            );
         }
+        false
     }
 
     pub fn is_number(&self) -> bool {
         if let TypeDef::Native(type_name) = *self {
-            match type_name {
-                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64" => true,
-                _ => false,
-            }
-        } else {
-            false
+            return matches!(
+                type_name,
+                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64"
+            );
         }
+        false
     }
 
     pub fn is_bool(&self) -> bool {
@@ -79,7 +77,7 @@ impl<'a> Header<'a> {
         }
     }
 
-    pub fn headers(mut self, declarations: &'a Vec<Decl>) -> Header<'a> {
+    pub fn headers(mut self, declarations: &'a [Decl]) -> Header<'a> {
         for declaration in declarations {
             self.visit_decl(declaration);
         }
@@ -99,7 +97,7 @@ impl<'a> Header<'a> {
         &self,
         name: &'a Token,
         return_type: &'a Token,
-        params: &'a Vec<(Token, Token)>,
+        params: &'a [(Token, Token)],
     ) -> Rc<TypeDef<'a>> {
         let mut parameters = HashMap::new();
         for (param_name, param_type) in params {
@@ -130,8 +128,8 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
     fn visit_struct(
         &mut self,
         name: &'a Token,
-        fields: &'a Vec<(Token, Token)>,
-        methods: &'a Vec<Rc<Decl>>,
+        fields: &'a [(Token, Token)],
+        methods: &'a [Rc<Decl>],
     ) {
         let struct_name = name.identifier();
 
@@ -167,7 +165,7 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
         &mut self,
         name: &'a Token,
         return_type: &'a Token,
-        params: &'a Vec<(Token, Token)>,
+        params: &'a [(Token, Token)],
         _: &Stmt,
     ) {
         self.fields.insert(

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::lexer::Token;
+use crate::ast::{Decl, DeclVisitor, Stmt, Expr};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeDef<'a> {
+    Struct {
+        name: &'a str,
+        members: HashMap<&'a str, Rc<TypeDef<'a>>>
+    },
+    Function {
+        name: &'a str,
+        parameters: HashMap<&'a str, Rc<TypeDef<'a>>>,
+        return_type: Rc<TypeDef<'a>>
+    },
+    Native(&'static str),
+    Lazy(&'a str)
+}
+
+impl TypeDef<'_> {
+    pub fn is_integer(&self) -> bool {
+        if let TypeDef::Native(type_name) = *self {
+            match type_name {
+                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" => true,
+                _ => false   
+            }
+        } else {
+            false
+        }
+    }
+
+    pub fn is_number(&self) -> bool {
+        if let TypeDef::Native(type_name) = *self {
+            match type_name {
+                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64" => true,
+                _ => false   
+            }
+        } else {
+            false
+        }
+    }
+
+    pub fn is_bool(&self) -> bool {
+        if let TypeDef::Native(type_name) = *self {
+            type_name == "bool"
+        } else {
+            false
+        }
+    }
+}
+
+pub struct Header<'a> {
+    types: HashMap<&'a str, Rc<TypeDef<'a>>>,
+    fields: HashMap<&'a str, Rc<TypeDef<'a>>>,
+}
+
+impl<'a> Header<'a> {
+    pub fn new() -> Header<'a> {
+        Header {
+            types: HashMap::from([
+                ("u8", Rc::new(TypeDef::Native("u8"))),
+                ("u16", Rc::new(TypeDef::Native("u16"))),
+                ("u32", Rc::new(TypeDef::Native("u32"))),
+                ("u64", Rc::new(TypeDef::Native("u64"))),
+                ("i8", Rc::new(TypeDef::Native("i8"))),
+                ("i16", Rc::new(TypeDef::Native("i16"))),
+                ("i32", Rc::new(TypeDef::Native("i32"))),
+                ("i64", Rc::new(TypeDef::Native("i64"))),
+                ("f32", Rc::new(TypeDef::Native("f32"))),
+                ("f64", Rc::new(TypeDef::Native("f64"))),
+                ("bool", Rc::new(TypeDef::Native("bool"))),
+                ("char", Rc::new(TypeDef::Native("char"))),
+                ("str", Rc::new(TypeDef::Native("str"))),
+                ("void", Rc::new(TypeDef:: Native("void")))
+            ]),
+            fields: HashMap::new()
+        }
+    }
+
+    pub fn headers(mut self, declarations: &'a Vec<Decl>) -> Header<'a> {
+        for declaration in declarations {
+            self.visit_decl(declaration);
+        }
+        self
+    }
+
+    pub fn analysed(self) -> (HashMap<&'a str, Rc<TypeDef<'a>>>, HashMap<&'a str, Rc<TypeDef<'a>>>) {
+        (self.types, self.fields)
+    }
+
+    fn make_function(&self, name: &'a Token, return_type: &'a Token, params: &'a Vec<(Token, Token)>) -> Rc<TypeDef<'a>> {
+        let mut parameters = HashMap::new();
+        for (param_name, param_type) in params {
+            parameters.insert(param_name.identifier(), self.get_type(param_type));
+        }
+        Rc::new(TypeDef::Function { name: name.identifier(), parameters, return_type: self.get_type(return_type) })
+    }
+
+    fn get_type(&self, name: &'a Token) -> Rc<TypeDef<'a>> {
+        let ref_name = name.identifier();
+        if let Some(ref_type) = self.types.get(ref_name) {
+            ref_type.clone()
+        } else {
+            Rc::new(TypeDef::Lazy(ref_name))
+        }
+        
+    }
+}
+
+impl<'a> DeclVisitor<'a, ()> for Header<'a> {
+    fn visit_import(&mut self, _: &'a Token) {
+        // TODO: open import file and add imported fields and types here
+    }
+
+    fn visit_struct(
+        &mut self,
+        name: &'a Token,
+        fields: &'a Vec<(Token, Token)>,
+        methods: &'a Vec<Rc<Decl>>,
+    ) {
+        let struct_name = name.identifier();
+
+        let mut members = HashMap::new();
+        for (field_name, field_type) in fields {
+            members.insert(field_name.identifier(), self.get_type(field_type));
+        }
+        for decl in methods {
+            if let Decl::Function { name, return_type, params, .. } = &**decl {
+                members.insert(name.identifier(), self.make_function(name, return_type, params));
+            }
+        }
+
+        self.types.insert(struct_name, Rc::new(TypeDef::Struct { name: struct_name, members }));
+    }
+
+    fn visit_function(
+        &mut self,
+        name: &'a Token,
+        return_type: &'a Token,
+        params: &'a Vec<(Token, Token)>,
+        _: &Stmt,
+    ) {
+        self.fields.insert(name.identifier(), self.make_function(name, return_type, params));
+    }
+
+    fn visit_const(&mut self, name: &'a Token, var_type: &'a Token, _: &Expr) {
+        self.fields.insert(name.identifier(), self.get_type(var_type));
+    }
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::iter::Peekable;
 use std::str::Chars;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
 pub struct Token {
     token_type: TokenType,
@@ -21,6 +21,14 @@ impl Token {
 
     pub fn get_type(&self) -> &TokenType {
         &self.token_type
+    }
+
+    pub fn identifier(&self) -> &str {
+        match self.get_type() {
+            TokenType::Identifier(name) => name,
+            TokenType::VSelf => "self",
+            _ => panic!("expected identifier"),
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,11 +45,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::StmtVisitor,
-        header::{self, Header},
-        lexer::Lexer,
-        parser::Parser,
-        resolution::Resolution,
+        ast::StmtVisitor, header::Header, lexer::Lexer, parser::Parser, resolution::Resolution,
     };
     use std::fs;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
-use crate::{lexer::Lexer, parser::Parser};
+use crate::{
+    ast::StmtVisitor, header::Header, lexer::Lexer, parser::Parser, resolution::Resolution,
+};
 use std::{env, fs, io};
 
 mod ast;
+mod header;
 mod lexer;
 mod parser;
+mod resolution;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -15,7 +19,10 @@ fn main() {
                 let tokens = lexer.scan();
                 if tokens.len() > 1 {
                     let mut parser = Parser::new(tokens);
-                    println!("{:#?}", parser.stmt());
+                    let ast = parser.stmt();
+                    let mut resolution = Resolution::new(Header::new());
+                    resolution.visit_stmt(&ast);
+                    println!("{:#?}", resolution);
                     buffer.clear();
                 } else {
                     break;
@@ -26,7 +33,10 @@ fn main() {
             let content = fs::read_to_string(args.get(1).unwrap()).expect("Expected to open file");
             let lexer = Lexer::new(content.chars());
             let parser = Parser::new(lexer.scan());
-            println!("{:#?}", parser.parse());
+            let ast = parser.parse();
+            let header = Header::new().headers(&ast);
+            let resolution = Resolution::new(header);
+            println!("{:#?}", resolution.resolve(&ast).analysed());
         }
         _ => println!("usage: {:?} [file]", args.first().unwrap()),
     }
@@ -34,7 +44,13 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use crate::{lexer::Lexer, parser::Parser};
+    use crate::{
+        ast::StmtVisitor,
+        header::{self, Header},
+        lexer::Lexer,
+        parser::Parser,
+        resolution::Resolution,
+    };
     use std::fs;
 
     #[test]
@@ -58,5 +74,25 @@ mod tests {
         let lexer = Lexer::new(content.chars());
         let mut parser = Parser::new(lexer.scan());
         println!("{:?}", parser.stmt());
+    }
+
+    #[test]
+    fn header_file() {
+        let content = fs::read_to_string("examples/vec2.tau").expect("Expected to open file");
+        let lexer = Lexer::new(content.chars());
+        let parser = Parser::new(lexer.scan());
+        let ast = parser.parse();
+        let header = Header::new();
+        println!("{:?}", header.headers(&ast).analysed());
+    }
+
+    #[test]
+    fn resolve_stmt() {
+        let content = "{ let a = 2 if (a < 2) break }";
+        let lexer = Lexer::new(content.chars());
+        let mut parser = Parser::new(lexer.scan());
+        let ast = parser.stmt();
+        let mut resolution = Resolution::new(Header::new());
+        println!("{:#?}", resolution.visit_stmt(&ast));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -258,11 +258,20 @@ impl Parser {
 
     fn expr_binary(&mut self, lhs: Expr, bp: u8) -> Expr {
         let next = self.advance();
-        let rhs = self.expr_bp(bp);
-        Expr::Binary {
-            left: Rc::new(lhs),
-            operator: next,
-            right: Rc::new(rhs),
+        if *next.get_type() == TokenType::Dot {
+            let rhs = self.advance();
+            assert!(rhs.get_type().is_identifer());
+            Expr::Get {
+                left: Rc::new(lhs),
+                right: rhs,
+            }
+        } else {
+            let rhs = self.expr_bp(bp);
+            Expr::Binary {
+                left: Rc::new(lhs),
+                operator: next,
+                right: Rc::new(rhs),
+            }
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -129,7 +129,7 @@ impl Parser {
                 Stmt::Break
             }
             TokenType::While => self.stmt_while(),
-            _ => Stmt::Expr(self.expr()),
+            _ => Stmt::ExprStmt(self.expr()),
         }
     }
 

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -200,11 +200,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
         todo!()
     }
 
-    fn visit_call(
-        &mut self,
-        callee: &'a Rc<Expr>,
-        arguments: &'a Vec<Rc<Expr>>,
-    ) -> Rc<TypeDef<'a>> {
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> Rc<TypeDef<'a>> {
         let callee_type = self.visit_expr(callee);
         if let TypeDef::Function {
             name,
@@ -225,7 +221,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
     fn visit_create(
         &mut self,
         struct_name: &'a Token,
-        fields: &'a Vec<(Token, Rc<Expr>)>,
+        fields: &'a [(Token, Rc<Expr>)],
     ) -> Rc<TypeDef<'a>> {
         let name = struct_name.identifier();
         let ref_type = if let Some(ref_type) = self.types.get(name) {
@@ -264,7 +260,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
             }
         }
         if let Some(branch) = else_branch {
-            if let Some(_) = self.visit_stmt(branch) {
+            if self.visit_stmt(branch).is_some() {
                 panic!("non expressive if has a expressive else branch");
             }
         }
@@ -292,7 +288,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
 }
 
 impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
-    fn visit_block(&mut self, statements: &'a Vec<Rc<Stmt>>) -> Option<Rc<TypeDef<'a>>> {
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Option<Rc<TypeDef<'a>>> {
         self.begin_scope();
         for stmt in statements {
             assert!(self.return_type.is_none(), "function has already returned");
@@ -350,12 +346,7 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
 impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
     fn visit_import(&mut self, _: &Token) {}
 
-    fn visit_struct(
-        &mut self,
-        name: &'a Token,
-        _: &'a Vec<(Token, Token)>,
-        methods: &'a Vec<Rc<Decl>>,
-    ) {
+    fn visit_struct(&mut self, name: &'a Token, _: &'a [(Token, Token)], methods: &'a [Rc<Decl>]) {
         self.begin_scope();
         let struct_type = self
             .types
@@ -376,7 +367,7 @@ impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
         &mut self,
         _: &'a Token,
         return_type: &'a Token,
-        params: &'a Vec<(Token, Token)>,
+        params: &'a [(Token, Token)],
         body: &'a Stmt,
     ) {
         assert!(self.return_type.is_none());

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,0 +1,409 @@
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use crate::ast::DeclVisitor;
+use crate::ast::ExprVisitor;
+use crate::ast::StmtVisitor;
+use crate::ast::{Decl, Expr, Stmt};
+use crate::header::Header;
+use crate::header::TypeDef;
+use crate::lexer::{Token, TokenType};
+
+#[derive(Debug)]
+pub struct Resolution<'a> {
+    types: HashMap<&'a str, Rc<TypeDef<'a>>>,
+    // Current scopes is the deque of all scopes we visited once. The map contains all
+    // variable names mapped to its type.
+    all_scopes: VecDeque<HashMap<&'a str, Rc<TypeDef<'a>>>>,
+    // Current scopes is the deque of the scope we are currently in and all scopes above it.
+    current_scopes: VecDeque<HashMap<&'a str, Rc<TypeDef<'a>>>>,
+    return_type: Option<Rc<TypeDef<'a>>>,
+}
+
+impl<'a> Resolution<'a> {
+    pub fn new(header: Header<'a>) -> Resolution<'a> {
+        let (types, fields) = header.analysed();
+        Resolution {
+            types,
+            all_scopes: VecDeque::new(),
+            current_scopes: VecDeque::from([fields]),
+            return_type: None,
+        }
+    }
+
+    pub fn resolve(mut self, declarations: &'a Vec<Decl>) -> Self {
+        for decl in declarations {
+            self.visit_decl(decl)
+        }
+        // When we create a new resolution, we already start in the global scope.
+        // After visiting all declarations, we need to end the global scope and
+        // push it to all scopes.
+        self.end_scope();
+        self
+    }
+
+    pub fn analysed(
+        self,
+    ) -> (
+        HashMap<&'a str, Rc<TypeDef<'a>>>,
+        VecDeque<HashMap<&'a str, Rc<TypeDef<'a>>>>,
+    ) {
+        (self.types, self.all_scopes)
+    }
+
+    fn declare_variable(&mut self, var_name: &'a Token, var_type: Rc<TypeDef<'a>>) {
+        assert!(
+            self.current_scopes
+                .back_mut()
+                .expect("expected scope")
+                .insert(var_name.identifier(), var_type)
+                .is_none()
+        );
+    }
+
+    fn lookup_variable(&mut self, var_name: &Token) -> Rc<TypeDef<'a>> {
+        match self.current_scopes.back() {
+            Some(scope) => match scope.get(var_name.identifier()) {
+                Some(v) => v.clone(),
+                _ => {
+                    let origin = self.current_scopes.pop_back().expect("expected scope");
+                    let var_type = self.lookup_variable(var_name);
+                    self.current_scopes.push_back(origin);
+                    var_type
+                }
+            },
+            _ => panic!("could not find variable '{}'", var_name.identifier()),
+        }
+    }
+
+    fn get_type(&self, name: &str) -> Rc<TypeDef<'a>> {
+        let ref_type: Rc<TypeDef<'a>> = self
+            .types
+            .get(name)
+            .expect(
+                format!(
+                    "expected type name does not exist '{}' in {:#?}",
+                    name, self
+                )
+                .as_str(),
+            )
+            .clone();
+        if let TypeDef::Lazy(lazy_name) = *ref_type {
+            self.get_type(lazy_name)
+        } else {
+            ref_type
+        }
+    }
+
+    fn get_member(&self, struct_type: Rc<TypeDef<'a>>, member_name: &'a str) -> Rc<TypeDef<'a>> {
+        if let TypeDef::Struct { name: _, members } = &*struct_type {
+            let ref_type: Rc<TypeDef<'a>> = members
+                .get(member_name)
+                .expect("expected struct contains field")
+                .clone();
+            if let TypeDef::Lazy(lazy_name) = *ref_type {
+                self.get_type(lazy_name)
+            } else {
+                ref_type
+            }
+        } else {
+            panic!("expected struct")
+        }
+    }
+
+    fn begin_scope(&mut self) {
+        self.current_scopes.push_back(HashMap::new());
+    }
+
+    fn end_scope(&mut self) {
+        let old_scope = self.current_scopes.pop_back().expect("expect end scope");
+        self.all_scopes.push_front(old_scope);
+    }
+}
+
+impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
+    fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> Rc<TypeDef<'a>> {
+        let r = self.visit_expr(right);
+        match operator.get_type() {
+            TokenType::Not => {
+                assert!(r.is_bool());
+                r
+            }
+            TokenType::Add | TokenType::Sub => {
+                assert!(r.is_number());
+                r
+            }
+            _ => unreachable!("{:?}", operator),
+        }
+    }
+
+    fn visit_binary(
+        &mut self,
+        left: &'a Rc<Expr>,
+        operator: &Token,
+        right: &'a Rc<Expr>,
+    ) -> Rc<TypeDef<'a>> {
+        let l = self.visit_expr(left);
+        let r = self.visit_expr(right);
+        match operator.get_type() {
+            TokenType::Add
+            | TokenType::Sub
+            | TokenType::Mul
+            | TokenType::Div
+            | TokenType::SetAdd
+            | TokenType::SetSub
+            | TokenType::SetMul
+            | TokenType::SetDiv => {
+                assert!(l.is_number());
+                assert!(r.is_number());
+                // TODO: choose larger number type out of left and right
+                r
+            }
+            TokenType::And | TokenType::Or | TokenType::Xor => {
+                assert!(l.is_bool());
+                assert!(r.is_bool());
+                l
+            }
+            TokenType::Leq | TokenType::Low | TokenType::Geq | TokenType::Gre => {
+                assert!(l.is_number());
+                assert!(r.is_number());
+                l
+            }
+            TokenType::Eq | TokenType::Neq => {
+                if l.is_number() {
+                    assert!(r.is_number());
+                } else {
+                    assert_eq!(l, r);
+                }
+                l
+            }
+            TokenType::Set => {
+                // TODO: check if right type can be cast to left
+                assert_eq!(l, r);
+                l
+            }
+            _ => unreachable!("{:?}", operator),
+        }
+    }
+
+    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Token) -> Rc<TypeDef<'a>> {
+        let l = self.visit_expr(left);
+        let r = right.identifier();
+        self.get_member(l, r)
+    }
+
+    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> Rc<TypeDef<'a>> {
+        let l = self.visit_expr(object);
+        let r = self.visit_expr(index);
+        assert!(r.is_integer());
+        todo!()
+    }
+
+    fn visit_call(
+        &mut self,
+        callee: &'a Rc<Expr>,
+        arguments: &'a Vec<Rc<Expr>>,
+    ) -> Rc<TypeDef<'a>> {
+        let callee_type = self.visit_expr(callee);
+        if let TypeDef::Function {
+            name,
+            parameters,
+            return_type,
+        } = &*callee_type
+        {
+            for argument in arguments {
+                // TODO: check argument type
+                self.visit_expr(argument);
+            }
+            return_type.clone()
+        } else {
+            panic!("expected to call function")
+        }
+    }
+
+    fn visit_create(
+        &mut self,
+        struct_name: &'a Token,
+        fields: &'a Vec<(Token, Rc<Expr>)>,
+    ) -> Rc<TypeDef<'a>> {
+        let name = struct_name.identifier();
+        let ref_type = if let Some(ref_type) = self.types.get(name) {
+            ref_type.clone()
+        } else {
+            panic!("use of undeclared struct type");
+        };
+
+        for (field_name, field_expr) in fields {
+            let field_type = self.visit_expr(field_expr);
+            assert_eq!(
+                self.get_member(ref_type.clone(), field_name.identifier()),
+                field_type
+            );
+        }
+        ref_type
+    }
+
+    fn visit_if(
+        &mut self,
+        condition: &'a Rc<Expr>,
+        if_branch: &'a Rc<Stmt>,
+        else_branch: &'a Option<Rc<Stmt>>,
+    ) -> Rc<TypeDef<'a>> {
+        self.visit_expr(condition);
+        if let Some(if_type) = self.visit_stmt(if_branch) {
+            if let Some(branch) = else_branch {
+                if let Some(else_type) = self.visit_stmt(branch) {
+                    assert_eq!(if_type, else_type);
+                    return if_type;
+                } else {
+                    panic!("return type of if branch does not match else branch");
+                }
+            } else {
+                panic!("expression if expected else branch")
+            }
+        }
+        if let Some(branch) = else_branch {
+            if let Some(_) = self.visit_stmt(branch) {
+                panic!("non expressive if has a expressive else branch");
+            }
+        }
+        self.types
+            .get("void")
+            .expect("expected native type void exists")
+            .clone()
+    }
+
+    fn visit_literal(&mut self, value: &Token) -> Rc<TypeDef<'a>> {
+        self.types
+            .get(match value.get_type() {
+                TokenType::Number(_) => "i32",
+                TokenType::String(_) => "str",
+                TokenType::Bool(_) => "bool",
+                _ => unreachable!(),
+            })
+            .expect("native type exists")
+            .clone()
+    }
+
+    fn visit_variable(&mut self, name: &Token) -> Rc<TypeDef<'a>> {
+        self.lookup_variable(name)
+    }
+}
+
+impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
+    fn visit_block(&mut self, statements: &'a Vec<Rc<Stmt>>) -> Option<Rc<TypeDef<'a>>> {
+        self.begin_scope();
+        for stmt in statements {
+            assert!(self.return_type.is_none(), "function has already returned");
+            self.visit_stmt(stmt);
+        }
+        self.end_scope();
+        None
+    }
+
+    fn visit_let(&mut self, name: &'a Token, initializer: &'a Expr) -> Option<Rc<TypeDef<'a>>> {
+        let var_type = self.visit_expr(initializer);
+        self.declare_variable(name, var_type);
+        None
+    }
+
+    fn visit_return(&mut self, value: &'a Expr) -> Option<Rc<TypeDef<'a>>> {
+        self.return_type = Some(self.visit_expr(value));
+        None
+    }
+
+    fn visit_break(&mut self) -> Option<Rc<TypeDef<'a>>> {
+        None
+    }
+
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Option<Rc<TypeDef<'a>>> {
+        self.begin_scope();
+        assert!(self.visit_expr(condition).is_bool());
+        self.visit_stmt(body);
+        self.end_scope();
+        None
+    }
+
+    fn visit_for(
+        &mut self,
+        initializer: &'a Rc<Stmt>,
+        condition: &'a Expr,
+        increment: &'a Expr,
+        body: &'a Rc<Stmt>,
+    ) -> Option<Rc<TypeDef<'a>>> {
+        self.begin_scope();
+        self.visit_stmt(initializer);
+        assert!(self.visit_expr(condition).is_bool());
+        // We don't check the return type of the increment expression, because we allow any type
+        self.visit_expr(increment);
+        self.visit_stmt(body);
+        self.end_scope();
+        None
+    }
+
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Option<Rc<TypeDef<'a>>> {
+        Some(self.visit_expr(expr))
+    }
+}
+
+impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
+    fn visit_import(&mut self, _: &Token) {}
+
+    fn visit_struct(
+        &mut self,
+        name: &'a Token,
+        _: &'a Vec<(Token, Token)>,
+        methods: &'a Vec<Rc<Decl>>,
+    ) {
+        self.begin_scope();
+        let struct_type = self
+            .types
+            .get(name.identifier())
+            .expect("expected to find own struct name when trying to reference self")
+            .clone();
+        self.current_scopes
+            .back_mut()
+            .expect("expected scope")
+            .insert("self", struct_type);
+        for method in methods {
+            self.visit_decl(method);
+        }
+        self.end_scope();
+    }
+
+    fn visit_function(
+        &mut self,
+        _: &'a Token,
+        return_type: &'a Token,
+        params: &'a Vec<(Token, Token)>,
+        body: &'a Stmt,
+    ) {
+        assert!(self.return_type.is_none());
+        self.begin_scope();
+        for (param_name, param_type) in params {
+            self.declare_variable(param_name, self.get_type(param_type.identifier()));
+        }
+        self.visit_stmt(body);
+        assert_eq!(
+            self.get_type(return_type.identifier()),
+            self.return_type
+                .clone()
+                .unwrap_or_else(|| { self.get_type("void") })
+        );
+        self.return_type = None;
+        self.end_scope();
+    }
+
+    fn visit_const(
+        &mut self,
+        _: &'a crate::lexer::Token,
+        var_type: &'a crate::lexer::Token,
+        initializer: &'a crate::ast::Expr,
+    ) {
+        assert_eq!(
+            self.get_type(var_type.identifier()),
+            self.visit_expr(initializer)
+        );
+    }
+}


### PR DESCRIPTION
This pull request adds headers and resolution. It implements a simple static type system with type checks over assertions. It can check which types were declared, which types which variable has, if arguments supplied to a constructor match the expected type, and much more...

Please note that headers currently don't support importing files or modules.

In addition, this pull request creates visitor traits. These traits are used to traverse complex data structures like our abstract syntax tree. For more information about visitors, look at the following book [rust design patterns](https://rust-unofficial.github.io/patterns/rust-design-patterns.pdf).