### PR TITLE
Allow optional type declarations

### DIFF
--- a/examples/arrays.tau
+++ b/examples/arrays.tau
@@ -1,0 +1,8 @@
+fn main() {
+    let a = u32[16] { 0, 0 }
+    let i = 0
+    while (i < 16) {
+        a[i] = i
+        i += 1
+    }
+}

--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -46,3 +46,7 @@ fn new(x: f64, y: f64): vec2 {
     let created = vec2 { x=x, y=y }
     return created
 }
+
+fn main() {
+    let a: vec2 = new(3, 4).add(4, -2)
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -99,6 +99,7 @@ pub enum Stmt {
     },
     Let {
         name: Token,
+        var_type: Option<Token>,
         initializer: Expr,
     },
     Return {
@@ -122,7 +123,11 @@ pub trait StmtVisitor<'a, T> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) -> T {
         match stmt {
             Stmt::Block { statements } => self.visit_block(statements),
-            Stmt::Let { name, initializer } => self.visit_let(name, initializer),
+            Stmt::Let {
+                name,
+                var_type,
+                initializer,
+            } => self.visit_let(name, var_type, initializer),
             Stmt::Return { value } => self.visit_return(value),
             Stmt::Break => self.visit_break(),
             Stmt::While { condition, body } => self.visit_while(condition, body),
@@ -138,7 +143,12 @@ pub trait StmtVisitor<'a, T> {
 
     fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> T;
 
-    fn visit_let(&mut self, name: &'a Token, initializer: &'a Expr) -> T;
+    fn visit_let(
+        &mut self,
+        name: &'a Token,
+        var_type: &'a Option<Token>,
+        initializer: &'a Expr,
+    ) -> T;
 
     fn visit_return(&mut self, value: &'a Expr) -> T;
 
@@ -167,7 +177,7 @@ pub enum Decl {
     },
     Function {
         name: Token,
-        return_type: Token,
+        return_type: Option<Token>,
         params: Vec<(Token, Token)>,
         body: Vec<Stmt>,
     },
@@ -213,7 +223,7 @@ pub trait DeclVisitor<'a, T> {
     fn visit_function(
         &mut self,
         name: &'a Token,
-        return_type: &'a Token,
+        return_type: &'a Option<Token>,
         params: &'a [(Token, Token)],
         body: &'a [Stmt],
     ) -> T;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -28,7 +28,12 @@ pub enum Expr {
         callee: Rc<Expr>,
         arguments: Vec<Rc<Expr>>,
     },
-    Create {
+    CreateArray {
+        array_type: Token,
+        array_size: Option<Rc<Expr>>,
+        fields: Vec<Rc<Expr>>,
+    },
+    CreateStruct {
         struct_name: Token,
         fields: Vec<(Token, Rc<Expr>)>,
     },
@@ -53,10 +58,15 @@ pub trait ExprVisitor<'a, T> {
             Expr::Get { left, right } => self.visit_get(left, right),
             Expr::Index { object, index } => self.visit_index(object, index),
             Expr::Call { callee, arguments } => self.visit_call(callee, arguments),
-            Expr::Create {
+            Expr::CreateArray {
+                array_type,
+                array_size,
+                fields,
+            } => self.visit_create_array(array_type, array_size, fields),
+            Expr::CreateStruct {
                 struct_name,
                 fields,
-            } => self.visit_create(struct_name, fields),
+            } => self.visit_create_struct(struct_name, fields),
             Expr::If {
                 condition,
                 if_branch,
@@ -77,7 +87,15 @@ pub trait ExprVisitor<'a, T> {
 
     fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> T;
 
-    fn visit_create(&mut self, struct_name: &'a Token, fields: &'a [(Token, Rc<Expr>)]) -> T;
+    fn visit_create_array(
+        &mut self,
+        array_type: &'a Token,
+        array_size: &'a Option<Rc<Expr>>,
+        fields: &'a [Rc<Expr>],
+    ) -> T;
+
+    fn visit_create_struct(&mut self, struct_name: &'a Token, fields: &'a [(Token, Rc<Expr>)])
+    -> T;
 
     fn visit_if(
         &mut self,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,7 +2,6 @@ use crate::lexer::Token;
 use std::rc::Rc;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum Expr {
     Unary {
         // -right
@@ -159,7 +158,6 @@ pub trait StmtVisitor<'a, T> {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum Decl {
     Import(Token),
     Struct {
@@ -171,7 +169,7 @@ pub enum Decl {
         name: Token,
         return_type: Token,
         params: Vec<(Token, Token)>,
-        body: Stmt,
+        body: Vec<Stmt>,
     },
     Const {
         name: Token,
@@ -217,7 +215,7 @@ pub trait DeclVisitor<'a, T> {
         name: &'a Token,
         return_type: &'a Token,
         params: &'a [(Token, Token)],
-        body: &'a Stmt,
+        body: &'a [Stmt],
     ) -> T;
 
     fn visit_const(&mut self, name: &'a Token, var_type: &'a Token, initializer: &'a Expr) -> T;

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Display, Formatter, Result};
 use std::rc::Rc;
 
 use crate::ast::{Decl, DeclVisitor, Expr, Stmt};
@@ -12,10 +12,10 @@ pub enum TypeDef<'a> {
         members: HashMap<&'a str, Rc<TypeDef<'a>>>,
     },
     Function {
-        name: &'a str,
-        parameters: Vec<(&'a str, Rc<TypeDef<'a>>)>,
+        parameters: Vec<Rc<TypeDef<'a>>>,
         return_type: Rc<TypeDef<'a>>,
     },
+    Array(Rc<TypeDef<'a>>),
     Number {
         name: &'static str,
         size: u8,
@@ -62,12 +62,24 @@ impl<'a> TypeDef<'a> {
                 }
             }
             Self::Function {
-                name,
                 parameters,
                 return_type,
             } => {
-                // TODO: check if you can cast the function
-                return false;
+                let (this_para, this_return) = (parameters, return_type);
+                if let Self::Function {
+                    parameters,
+                    return_type,
+                } = to
+                {
+                    for (par_from, par_to) in this_para.iter().zip(parameters) {
+                        if !par_from.is_castable_to(par_to) {
+                            return false;
+                        }
+                    }
+                    return this_return.is_castable_to(return_type);
+                } else {
+                    return false;
+                }
             }
             Self::Struct { name, members: _ } => {
                 let this_name = name;
@@ -101,7 +113,7 @@ impl<'a> TypeDef<'a> {
             signed: _,
         } = *self
         {
-            return float;
+            return !float;
         }
         false
     }
@@ -132,24 +144,23 @@ impl<'a> TypeDef<'a> {
 }
 
 impl Display for TypeDef<'_> {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let name = match self {
-            Self::Struct { name, members: _ } => name,
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Struct { name, members: _ } => formatter.write_str(name),
             Self::Function {
-                name,
-                parameters: _,
-                return_type: _,
-            } => name,
+                parameters,
+                return_type,
+            } => write!(formatter, "{:?} -> {}", parameters, return_type),
+            Self::Array(array_type) => write!(formatter, "[{:?}]", array_type),
             Self::Number {
                 name,
                 size: _,
                 float: _,
                 signed: _,
-            } => name,
-            Self::Native(name) => name,
-            Self::Lazy(name) => name,
-        };
-        formatter.write_str(name)
+            } => formatter.write_str(name),
+            Self::Native(name) => formatter.write_str(name),
+            Self::Lazy(name) => formatter.write_str(name),
+        }
     }
 }
 
@@ -197,15 +208,14 @@ impl<'a> Header<'a> {
         (self.types, self.fields)
     }
 
-    fn make_function(
+    fn make_function_type(
         &self,
-        name: &'a Token,
         return_type: &'a Option<Token>,
         params: &'a [(Token, Token)],
     ) -> Rc<TypeDef<'a>> {
         let mut parameters = Vec::new();
-        for (param_name, param_type) in params {
-            parameters.push((param_name.identifier(), self.get_type(param_type)));
+        for (_, param_type) in params {
+            parameters.push(self.get_type(param_type));
         }
 
         let return_type = if let Some(type_name) = return_type {
@@ -218,7 +228,6 @@ impl<'a> Header<'a> {
         };
 
         Rc::new(TypeDef::Function {
-            name: name.identifier(),
             parameters,
             return_type,
         })
@@ -261,7 +270,7 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
             {
                 members.insert(
                     name.identifier(),
-                    self.make_function(name, return_type, params),
+                    self.make_function_type(return_type, params),
                 );
             }
         }
@@ -284,7 +293,7 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
     ) {
         self.fields.insert(
             name.identifier(),
-            self.make_function(name, return_type, params),
+            self.make_function_type(return_type, params),
         );
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
 use crate::ast::{Decl, DeclVisitor, Expr, Stmt};
@@ -12,28 +13,106 @@ pub enum TypeDef<'a> {
     },
     Function {
         name: &'a str,
-        parameters: HashMap<&'a str, Rc<TypeDef<'a>>>,
+        parameters: Vec<(&'a str, Rc<TypeDef<'a>>)>,
         return_type: Rc<TypeDef<'a>>,
+    },
+    Number {
+        name: &'static str,
+        size: u8,
+        float: bool,
+        signed: bool,
     },
     Native(&'static str),
     Lazy(&'a str),
 }
 
-impl TypeDef<'_> {
+impl<'a> TypeDef<'a> {
+    fn make_number(name: &'static str, size: u8, float: bool, signed: bool) -> TypeDef<'a> {
+        Self::Number {
+            name,
+            size,
+            float,
+            signed,
+        }
+    }
+
+    pub fn is_castable_to(&self, to: &Self) -> bool {
+        match self {
+            TypeDef::Number {
+                name: _,
+                size,
+                float,
+                signed: _,
+            } => {
+                let (this_size, this_float) = (size, float);
+                if let TypeDef::Number {
+                    name: _,
+                    size,
+                    float,
+                    signed: _,
+                } = to
+                {
+                    if *this_float {
+                        return *float && this_size <= size;
+                    } else {
+                        return this_size <= size;
+                    }
+                } else {
+                    return false;
+                }
+            }
+            TypeDef::Function {
+                name,
+                parameters,
+                return_type,
+            } => {
+                // TODO: check if you can cast the function
+                return false;
+            }
+            TypeDef::Struct { name, members: _ } => {
+                let this_name = name;
+                if let TypeDef::Struct { name, members: _ } = to {
+                    return this_name == name;
+                } else {
+                    return false;
+                }
+            }
+            Self::Native(this_name) => {
+                if let Self::Native(name) = to {
+                    return this_name == name;
+                } else {
+                    return false;
+                }
+            }
+            _ => {
+                panic!("tried to typecheck a lazy type that was not dereferenced yet")
+            }
+        }
+    }
+
     pub fn is_integer(&self) -> bool {
-        if let TypeDef::Native(type_name) = *self {
-            return matches!(
-                type_name,
-                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64"
-            );
+        if let TypeDef::Number {
+            name: _,
+            size: _,
+            float,
+            signed: _,
+        } = *self
+        {
+            return float;
         }
         false
     }
 
     pub fn is_number(&self) -> bool {
-        if let TypeDef::Native(type_name) = *self {
+        if let TypeDef::Number {
+            name,
+            size: _,
+            float: _,
+            signed: _,
+        } = *self
+        {
             return matches!(
-                type_name,
+                name,
                 "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64"
             );
         }
@@ -41,11 +120,33 @@ impl TypeDef<'_> {
     }
 
     pub fn is_bool(&self) -> bool {
-        if let TypeDef::Native(type_name) = *self {
-            type_name == "bool"
+        if let TypeDef::Native(name) = *self {
+            name == "bool"
         } else {
             false
         }
+    }
+}
+
+impl Display for TypeDef<'_> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let name = match self {
+            Self::Struct { name, members: _ } => name,
+            Self::Function {
+                name,
+                parameters: _,
+                return_type: _,
+            } => name,
+            Self::Number {
+                name,
+                size: _,
+                float: _,
+                signed: _,
+            } => name,
+            Self::Native(name) => name,
+            Self::Lazy(name) => name,
+        };
+        formatter.write_str(name)
     }
 }
 
@@ -58,16 +159,16 @@ impl<'a> Header<'a> {
     pub fn new() -> Header<'a> {
         Header {
             types: HashMap::from([
-                ("u8", Rc::new(TypeDef::Native("u8"))),
-                ("u16", Rc::new(TypeDef::Native("u16"))),
-                ("u32", Rc::new(TypeDef::Native("u32"))),
-                ("u64", Rc::new(TypeDef::Native("u64"))),
-                ("i8", Rc::new(TypeDef::Native("i8"))),
-                ("i16", Rc::new(TypeDef::Native("i16"))),
-                ("i32", Rc::new(TypeDef::Native("i32"))),
-                ("i64", Rc::new(TypeDef::Native("i64"))),
-                ("f32", Rc::new(TypeDef::Native("f32"))),
-                ("f64", Rc::new(TypeDef::Native("f64"))),
+                ("u8", Rc::new(TypeDef::make_number("u8", 1, false, false))),
+                ("u16", Rc::new(TypeDef::make_number("u16", 2, false, false))),
+                ("u32", Rc::new(TypeDef::make_number("u32", 4, false, false))),
+                ("u64", Rc::new(TypeDef::make_number("u64", 8, false, false))),
+                ("i8", Rc::new(TypeDef::make_number("i8", 1, false, true))),
+                ("i16", Rc::new(TypeDef::make_number("i16", 2, false, true))),
+                ("i32", Rc::new(TypeDef::make_number("i32", 4, false, true))),
+                ("i64", Rc::new(TypeDef::make_number("i64", 8, false, true))),
+                ("f32", Rc::new(TypeDef::make_number("f32", 4, true, true))),
+                ("f64", Rc::new(TypeDef::make_number("f64", 8, true, true))),
                 ("bool", Rc::new(TypeDef::Native("bool"))),
                 ("char", Rc::new(TypeDef::Native("char"))),
                 ("str", Rc::new(TypeDef::Native("str"))),
@@ -99,9 +200,9 @@ impl<'a> Header<'a> {
         return_type: &'a Token,
         params: &'a [(Token, Token)],
     ) -> Rc<TypeDef<'a>> {
-        let mut parameters = HashMap::new();
+        let mut parameters = Vec::new();
         for (param_name, param_type) in params {
-            parameters.insert(param_name.identifier(), self.get_type(param_type));
+            parameters.push((param_name.identifier(), self.get_type(param_type)));
         }
         Rc::new(TypeDef::Function {
             name: name.identifier(),
@@ -166,7 +267,7 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
         name: &'a Token,
         return_type: &'a Token,
         params: &'a [(Token, Token)],
-        _: &Stmt,
+        _: &[Stmt],
     ) {
         self.fields.insert(
             name.identifier(),

--- a/src/header.rs
+++ b/src/header.rs
@@ -38,14 +38,14 @@ impl<'a> TypeDef<'a> {
 
     pub fn is_castable_to(&self, to: &Self) -> bool {
         match self {
-            TypeDef::Number {
+            Self::Number {
                 name: _,
                 size,
                 float,
                 signed: _,
             } => {
                 let (this_size, this_float) = (size, float);
-                if let TypeDef::Number {
+                if let Self::Number {
                     name: _,
                     size,
                     float,
@@ -61,7 +61,7 @@ impl<'a> TypeDef<'a> {
                     return false;
                 }
             }
-            TypeDef::Function {
+            Self::Function {
                 name,
                 parameters,
                 return_type,
@@ -69,7 +69,7 @@ impl<'a> TypeDef<'a> {
                 // TODO: check if you can cast the function
                 return false;
             }
-            TypeDef::Struct { name, members: _ } => {
+            Self::Struct { name, members: _ } => {
                 let this_name = name;
                 if let TypeDef::Struct { name, members: _ } = to {
                     return this_name == name;
@@ -85,7 +85,10 @@ impl<'a> TypeDef<'a> {
                 }
             }
             _ => {
-                panic!("tried to typecheck a lazy type that was not dereferenced yet")
+                panic!(
+                    "tried to typecheck the lazy type '{}' that was not dereferenced yet",
+                    self
+                )
             }
         }
     }
@@ -197,17 +200,27 @@ impl<'a> Header<'a> {
     fn make_function(
         &self,
         name: &'a Token,
-        return_type: &'a Token,
+        return_type: &'a Option<Token>,
         params: &'a [(Token, Token)],
     ) -> Rc<TypeDef<'a>> {
         let mut parameters = Vec::new();
         for (param_name, param_type) in params {
             parameters.push((param_name.identifier(), self.get_type(param_type)));
         }
+
+        let return_type = if let Some(type_name) = return_type {
+            self.get_type(type_name)
+        } else {
+            self.types
+                .get("void")
+                .expect("expected void type exists")
+                .clone()
+        };
+
         Rc::new(TypeDef::Function {
             name: name.identifier(),
             parameters,
-            return_type: self.get_type(return_type),
+            return_type,
         })
     }
 
@@ -265,7 +278,7 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
     fn visit_function(
         &mut self,
         name: &'a Token,
-        return_type: &'a Token,
+        return_type: &'a Option<Token>,
         params: &'a [(Token, Token)],
         _: &[Stmt],
     ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
             while io::stdin().read_line(&mut buffer).is_ok() {
                 let lexer = Lexer::new(buffer.chars());
                 let tokens = lexer.scan();
+                // Check if user pressed ^D
                 if tokens.len() > 1 {
                     let mut parser = Parser::new(tokens);
                     let ast = parser.stmt();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -48,6 +48,7 @@ impl Parser {
     fn decl_function(&mut self) -> Decl {
         let name = self.advance();
         assert!(name.get_type().is_identifer(), "{:?}", name);
+
         self.consume(&TokenType::ParenLeft);
         let mut params = Vec::new();
         while *self.peek().get_type() != TokenType::ParenRight {
@@ -57,10 +58,18 @@ impl Parser {
             }
         }
         self.consume(&TokenType::ParenRight);
+
         self.consume(&TokenType::Colon);
         let return_type = self.advance();
         assert!(name.get_type().is_identifer(), "{:?}", name);
-        let body = self.stmt();
+
+        self.consume(&TokenType::BraceLeft);
+        let mut body = Vec::new();
+        while *self.peek().get_type() != TokenType::BraceRight {
+            body.push(self.stmt());
+        }
+        self.consume(&TokenType::BraceRight);
+
         Decl::Function {
             name,
             return_type,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 
 // Pratt parser inspired after the following block post:
 // https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
+#[derive(Debug)]
 pub struct Parser {
     tokens: VecDeque<Token>,
     declarations: Vec<Decl>,
@@ -197,7 +198,26 @@ impl Parser {
             TokenType::Bool(_) | TokenType::Number(_) | TokenType::String(_) => Expr::Literal(next),
             TokenType::Identifier(_) => {
                 if *self.peek().get_type() == TokenType::BraceLeft {
-                    self.expr_create(next)
+                    self.expr_create_struct(next)
+                } else if *self.peek().get_type() == TokenType::BracketLeft {
+                    self.advance();
+                    // The code below is needed to check if we create a new array or want to index a field.
+                    if *self.peek().get_type() == TokenType::BracketRight {
+                        self.advance();
+                        dbg!("create array");
+                        self.expr_create_array(next, None)
+                    } else {
+                        let expr = Rc::new(self.expr());
+                        self.consume(&TokenType::BracketRight);
+                        if *self.peek().get_type() == TokenType::BraceLeft {
+                            self.expr_create_array(next, Some(expr))
+                        } else {
+                            Expr::Index {
+                                object: Rc::new(Expr::Variable(next)),
+                                index: expr,
+                            }
+                        }
+                    }
                 } else {
                     Expr::Variable(next)
                 }
@@ -301,7 +321,25 @@ impl Parser {
         }
     }
 
-    fn expr_create(&mut self, struct_name: Token) -> Expr {
+    fn expr_create_array(&mut self, array_type: Token, array_size: Option<Rc<Expr>>) -> Expr {
+        self.consume(&TokenType::BraceLeft);
+        let mut fields = Vec::new();
+        while *self.peek().get_type() != TokenType::BraceRight {
+            fields.push(Rc::new(self.expr()));
+            if *self.peek().get_type() != TokenType::BraceRight {
+                self.consume(&TokenType::Comma);
+            }
+        }
+        self.consume(&TokenType::BraceRight);
+
+        Expr::CreateArray {
+            array_type,
+            array_size,
+            fields,
+        }
+    }
+
+    fn expr_create_struct(&mut self, struct_name: Token) -> Expr {
         self.consume(&TokenType::BraceLeft);
         let mut fields = Vec::new();
         while *self.peek().get_type() != TokenType::BraceRight {
@@ -316,7 +354,7 @@ impl Parser {
             }
         }
         self.consume(&TokenType::BraceRight);
-        Expr::Create {
+        Expr::CreateStruct {
             struct_name,
             fields,
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -59,9 +59,14 @@ impl Parser {
         }
         self.consume(&TokenType::ParenRight);
 
-        self.consume(&TokenType::Colon);
-        let return_type = self.advance();
-        assert!(name.get_type().is_identifer(), "{:?}", name);
+        let return_type = if *self.peek().get_type() != TokenType::BraceLeft {
+            self.consume(&TokenType::Colon);
+            let type_name = self.advance();
+            assert!(type_name.get_type().is_identifer());
+            Some(type_name)
+        } else {
+            None
+        };
 
         self.consume(&TokenType::BraceLeft);
         let mut body = Vec::new();
@@ -156,9 +161,21 @@ impl Parser {
         self.advance();
         let name = self.advance();
         assert!(name.get_type().is_identifer());
+        let var_type = if *self.peek().get_type() != TokenType::Set {
+            self.consume(&TokenType::Colon);
+            let type_name = self.advance();
+            assert!(type_name.get_type().is_identifer());
+            Some(type_name)
+        } else {
+            None
+        };
         self.consume(&TokenType::Set);
         let initializer = self.expr();
-        Stmt::Let { name, initializer }
+        Stmt::Let {
+            name,
+            var_type,
+            initializer,
+        }
     }
 
     fn stmt_while(&mut self) -> Stmt {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -157,8 +157,12 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
             | TokenType::SetDiv => {
                 assert!(l.is_number());
                 assert!(r.is_number());
-                // TODO: choose larger number type out of left and right
-                r
+                if l.is_castable_to(&r) {
+                    return r;
+                } else if r.is_castable_to(&l) {
+                    return l;
+                }
+                panic!("number types of left and right side do not match");
             }
             TokenType::And | TokenType::Or | TokenType::Xor => {
                 assert!(l.is_bool());
@@ -197,20 +201,26 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
         let l = self.visit_expr(object);
         let r = self.visit_expr(index);
         assert!(r.is_integer());
-        todo!()
+        todo!("arrays are currently not implemented")
     }
 
     fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> Rc<TypeDef<'a>> {
         let callee_type = self.visit_expr(callee);
         if let TypeDef::Function {
-            name,
+            name: _,
             parameters,
             return_type,
         } = &*callee_type
         {
-            for argument in arguments {
-                // TODO: check argument type
-                self.visit_expr(argument);
+            for (argument, (para_name, para_type)) in arguments.iter().zip(parameters) {
+                let arg_type = self.visit_expr(argument);
+                assert!(
+                    arg_type.is_castable_to(para_type),
+                    "argument type '{}' supplied to function does not match parameter '{}' of type '{}'",
+                    arg_type,
+                    para_name,
+                    para_type
+                )
             }
             return_type.clone()
         } else {
@@ -368,19 +378,26 @@ impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
         _: &'a Token,
         return_type: &'a Token,
         params: &'a [(Token, Token)],
-        body: &'a Stmt,
+        body: &'a [Stmt],
     ) {
         assert!(self.return_type.is_none());
         self.begin_scope();
         for (param_name, param_type) in params {
             self.declare_variable(param_name, self.get_type(param_type.identifier()));
         }
-        self.visit_stmt(body);
-        assert_eq!(
-            self.get_type(return_type.identifier()),
-            self.return_type
-                .clone()
-                .unwrap_or_else(|| { self.get_type("void") })
+        for stmt in body {
+            self.visit_stmt(stmt);
+        }
+        let expected = return_type.identifier();
+        let real = self
+            .return_type
+            .clone()
+            .unwrap_or_else(|| self.get_type("void"));
+        assert!(
+            real.is_castable_to(&self.get_type(expected)),
+            "could not cast {} to {}",
+            real,
+            expected
         );
         self.return_type = None;
         self.end_scope();

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -176,7 +176,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
             TokenType::Leq | TokenType::Low | TokenType::Geq | TokenType::Gre => {
                 assert!(l.is_number());
                 assert!(r.is_number());
-                l
+                self.get_type("bool")
             }
             TokenType::Eq | TokenType::Neq => {
                 if l.is_number() {
@@ -187,8 +187,9 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
                 l
             }
             TokenType::Set => {
-                // TODO: check if right type can be cast to left
-                assert_eq!(l, r);
+                if !r.is_castable_to(&l) {
+                    panic!("can not cast right side of set expression to expected var type")
+                }
                 l
             }
             _ => unreachable!("{:?}", operator),
@@ -203,26 +204,28 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
 
     fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> Rc<TypeDef<'a>> {
         let l = self.visit_expr(object);
-        let r = self.visit_expr(index);
-        assert!(r.is_integer());
-        todo!("arrays are currently not implemented")
+        if let TypeDef::Array(array_type) = &*l {
+            let r = self.visit_expr(index);
+            assert!(r.is_integer());
+            self.get_ref_type(array_type.clone())
+        } else {
+            panic!("expected to index array")
+        }
     }
 
     fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> Rc<TypeDef<'a>> {
         let callee_type = self.visit_expr(callee);
         if let TypeDef::Function {
-            name: _,
             parameters,
             return_type,
         } = &*callee_type
         {
-            for (argument, (para_name, para_type)) in arguments.iter().zip(parameters) {
+            for (argument, para_type) in arguments.iter().zip(parameters) {
                 let arg_type = self.visit_expr(argument);
                 assert!(
                     arg_type.is_castable_to(&*self.get_ref_type(para_type.clone())),
-                    "argument type '{}' supplied to function does not match parameter '{}' of type '{}'",
+                    "argument type '{}' supplied to function does not match parameter type '{}'",
                     arg_type,
-                    para_name,
                     para_type
                 )
             }
@@ -232,7 +235,25 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
         }
     }
 
-    fn visit_create(
+    fn visit_create_array(
+        &mut self,
+        array_type: &'a Token,
+        array_size: &'a Option<Rc<Expr>>,
+        fields: &'a [Rc<Expr>],
+    ) -> Rc<TypeDef<'a>> {
+        let name = array_type.identifier();
+        if let Some(size_expr) = array_size {
+            assert!(self.visit_expr(size_expr).is_integer());
+        }
+        let ref_type = self.get_type(name);
+        for field in fields {
+            assert!(self.visit_expr(field).is_castable_to(&ref_type))
+        }
+
+        Rc::new(TypeDef::Array(ref_type))
+    }
+
+    fn visit_create_struct(
         &mut self,
         struct_name: &'a Token,
         fields: &'a [(Token, Rc<Expr>)],
@@ -343,7 +364,10 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
 
     fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Option<Rc<TypeDef<'a>>> {
         self.begin_scope();
-        assert!(self.visit_expr(condition).is_bool());
+        assert!(
+            self.visit_expr(condition).is_bool(),
+            "expected while condition is boolean"
+        );
         self.visit_stmt(body);
         self.end_scope();
         None

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -89,6 +89,10 @@ impl<'a> Resolution<'a> {
                 .as_str(),
             )
             .clone();
+        self.get_ref_type(ref_type)
+    }
+
+    fn get_ref_type(&self, ref_type: Rc<TypeDef<'a>>) -> Rc<TypeDef<'a>> {
         if let TypeDef::Lazy(lazy_name) = *ref_type {
             self.get_type(lazy_name)
         } else {
@@ -215,14 +219,14 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
             for (argument, (para_name, para_type)) in arguments.iter().zip(parameters) {
                 let arg_type = self.visit_expr(argument);
                 assert!(
-                    arg_type.is_castable_to(para_type),
+                    arg_type.is_castable_to(&*self.get_ref_type(para_type.clone())),
                     "argument type '{}' supplied to function does not match parameter '{}' of type '{}'",
                     arg_type,
                     para_name,
                     para_type
                 )
             }
-            return_type.clone()
+            self.get_ref_type(return_type.clone())
         } else {
             panic!("expected to call function")
         }
@@ -308,9 +312,23 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
         None
     }
 
-    fn visit_let(&mut self, name: &'a Token, initializer: &'a Expr) -> Option<Rc<TypeDef<'a>>> {
-        let var_type = self.visit_expr(initializer);
-        self.declare_variable(name, var_type);
+    fn visit_let(
+        &mut self,
+        name: &'a Token,
+        var_type: &'a Option<Token>,
+        initializer: &'a Expr,
+    ) -> Option<Rc<TypeDef<'a>>> {
+        let real_type = self.visit_expr(initializer);
+        if let Some(expected_type) = &*var_type {
+            let ref_type = self.get_type(expected_type.identifier());
+            if real_type.is_castable_to(&ref_type) {
+                self.declare_variable(name, ref_type);
+            } else {
+                panic!();
+            }
+        } else {
+            self.declare_variable(name, real_type);
+        }
         None
     }
 
@@ -376,7 +394,7 @@ impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
     fn visit_function(
         &mut self,
         _: &'a Token,
-        return_type: &'a Token,
+        return_type: &'a Option<Token>,
         params: &'a [(Token, Token)],
         body: &'a [Stmt],
     ) {
@@ -388,11 +406,16 @@ impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
         for stmt in body {
             self.visit_stmt(stmt);
         }
-        let expected = return_type.identifier();
-        let real = self
-            .return_type
-            .clone()
-            .unwrap_or_else(|| self.get_type("void"));
+        let expected = if let Some(type_name) = return_type {
+            type_name.identifier()
+        } else {
+            "void"
+        };
+        let real = self.get_ref_type(
+            self.return_type
+                .clone()
+                .unwrap_or_else(|| self.get_type("void")),
+        );
         assert!(
             real.is_castable_to(&self.get_type(expected)),
             "could not cast {} to {}",


### PR DESCRIPTION
A function is now parsed as a sequence of statements instead of a single statement.

Currently, let statements don't allow types and function declarations require a type. This pull request changes the parser so that it allows both. If a type declaration of a let statement is missing, it will assume the type of the initializer. If a type of a function declaration is missing, it will assume void.

Adds support for automatic type casting.