### PR TITLE
Add a basic C++ compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 result
 .direnv/
 target
+.pre-commit-config.yaml

--- a/examples/arrays.tau
+++ b/examples/arrays.tau
@@ -1,8 +1,14 @@
-fn main() {
-    let a = u32[16] { 0, 0 }
+extern fn println(data: str)
+
+extern fn i32_to_str(input: i32): str
+
+fn main(): i32 {
+    let a = i32[2 * 8] { 0, 0 }
     let i = 0
     while (i < 16) {
         a[i] = i
         i += 1
     }
+    println(i32_to_str(a[15]))
+    return 0
 }

--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -1,23 +1,19 @@
-import math
+extern fn sqrt(v: f64): f64
 
-fn sqrt(v: f64): f64 {
-    // We need this dummy function because imports
-    // are currently not supported
-    return v
-}
+extern fn println(v: str)
 
 struct vec2 {
     x: f64,
     y: f64
 
     fn add(x: f64, y: f64): vec2 {
-        self.x *= x
-        self.y *= y
+        self.x += x
+        self.y += y
         return self
     }
 
     fn sub(x: f64, y: f64): vec2 {
-        self.x *= x
+        self.x -= x
         self.y -= y
         return self
     }
@@ -32,7 +28,7 @@ struct vec2 {
     }
 
     fn copy(): vec2 {
-        return new(self.x, self.y)
+        return vec2_new(self.x, self.y)
     }
 
     fn magnitude(): f64 {
@@ -40,13 +36,15 @@ struct vec2 {
     }
 }
 
-const ZERO: vec2 = new(0, 0)
+const ZERO: vec2 = vec2 { x=0, y=0 }
 
-fn new(x: f64, y: f64): vec2 {
+fn vec2_new(x: f64, y: f64): vec2 {
     let created = vec2 { x=x, y=y }
     return created
 }
 
-fn main() {
-    let a: vec2 = new(3, 4).add(4, -2)
+fn main(): i32 {
+    let _a: vec2 = vec2_new(3, 4).add(4, -2)
+    println("Hello, World!")
+    return 0
 }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746537231,
-        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746498961,
-        "narHash": "sha256-rp+oh/N88JKHu7ySPuGiA3lBUVIsrOtHbN2eWJdYCgk=",
+        "lastModified": 1758335443,
+        "narHash": "sha256-2jaGMj32IckpZgBjn7kG4zyJl66T+2A1Fn2ppkHh91o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "24b00064cdd1d7ba25200c4a8565dc455dc732ba",
+        "rev": "f1ccb14649cf87e48051a6ac3a571b4a57d84ff3",
         "type": "github"
       },
       "original": {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -44,7 +44,7 @@ pub enum Expr {
     },
     Get {
         left: Rc<Expr>,
-        right: Token,
+        right: Identifier,
         lookup: TypeCell,
     },
     Index {
@@ -127,7 +127,7 @@ pub trait ExprVisitor<'a, T> {
 
     fn visit_binary(&mut self, left: &'a Rc<Expr>, operator: &'a Token, right: &'a Rc<Expr>) -> T;
 
-    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Token, lookup: &'a TypeCell) -> T;
+    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Identifier, lookup: &'a TypeCell) -> T;
 
     fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>, lookup: &'a TypeCell)
     -> T;
@@ -238,7 +238,7 @@ pub trait StmtVisitor<'a, T> {
 
 #[derive(Debug)]
 pub enum Decl {
-    Import(Token),
+    Import(Vec<Identifier>),
     Struct {
         name: Identifier,
         fields: Vec<(Identifier, TypeCell)>,
@@ -282,7 +282,7 @@ pub trait DeclVisitor<'a, T> {
         }
     }
 
-    fn visit_import(&mut self, name: &'a Token) -> T;
+    fn visit_import(&mut self, path: &'a [Identifier]) -> T;
 
     fn visit_struct(
         &mut self,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,33 @@
-use crate::lexer::Token;
-use std::rc::Rc;
+use crate::{
+    lexer::{Source, Token},
+    typing::TypeCell,
+};
+use std::{
+    fmt::{Display, Formatter, Result},
+    rc::Rc,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Identifier {
+    name: String,
+    source: Source,
+}
+
+impl Identifier {
+    pub fn new(name: String, source: Source) -> Self {
+        Identifier { name, source }
+    }
+
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Display for Identifier {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
+        formatter.write_str(&self.name)
+    }
+}
 
 #[derive(Debug)]
 pub enum Expr {
@@ -17,11 +45,13 @@ pub enum Expr {
     Get {
         left: Rc<Expr>,
         right: Token,
+        lookup: TypeCell,
     },
     Index {
         // object[index]
         object: Rc<Expr>,
         index: Rc<Expr>,
+        lookup: TypeCell,
     },
     Call {
         // callee(..arguments)
@@ -29,21 +59,25 @@ pub enum Expr {
         arguments: Vec<Rc<Expr>>,
     },
     CreateArray {
-        array_type: Token,
+        array_type: TypeCell,
         array_size: Option<Rc<Expr>>,
         fields: Vec<Rc<Expr>>,
     },
     CreateStruct {
-        struct_name: Token,
-        fields: Vec<(Token, Rc<Expr>)>,
+        struct_type: TypeCell,
+        fields: Vec<(Identifier, Rc<Expr>)>,
     },
     If {
         condition: Rc<Expr>,
         if_branch: Rc<Stmt>,
         else_branch: Option<Rc<Stmt>>,
+        expression_type: TypeCell,
     },
     Literal(Token),
-    Variable(Token),
+    Variable {
+        name: Identifier,
+        variable_type: TypeCell,
+    },
 }
 
 pub trait ExprVisitor<'a, T> {
@@ -55,8 +89,16 @@ pub trait ExprVisitor<'a, T> {
                 operator,
                 right,
             } => self.visit_binary(left, operator, right),
-            Expr::Get { left, right } => self.visit_get(left, right),
-            Expr::Index { object, index } => self.visit_index(object, index),
+            Expr::Get {
+                left,
+                right,
+                lookup,
+            } => self.visit_get(left, right, lookup),
+            Expr::Index {
+                object,
+                index,
+                lookup,
+            } => self.visit_index(object, index, lookup),
             Expr::Call { callee, arguments } => self.visit_call(callee, arguments),
             Expr::CreateArray {
                 array_type,
@@ -64,16 +106,20 @@ pub trait ExprVisitor<'a, T> {
                 fields,
             } => self.visit_create_array(array_type, array_size, fields),
             Expr::CreateStruct {
-                struct_name,
+                struct_type,
                 fields,
-            } => self.visit_create_struct(struct_name, fields),
+            } => self.visit_create_struct(struct_type, fields),
             Expr::If {
                 condition,
                 if_branch,
                 else_branch,
-            } => self.visit_if(condition, if_branch, else_branch),
+                expression_type,
+            } => self.visit_if(condition, if_branch, else_branch, expression_type),
             Expr::Literal(value) => self.visit_literal(value),
-            Expr::Variable(name) => self.visit_variable(name),
+            Expr::Variable {
+                name,
+                variable_type,
+            } => self.visit_variable(name, variable_type),
         }
     }
 
@@ -81,32 +127,37 @@ pub trait ExprVisitor<'a, T> {
 
     fn visit_binary(&mut self, left: &'a Rc<Expr>, operator: &'a Token, right: &'a Rc<Expr>) -> T;
 
-    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Token) -> T;
+    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Token, lookup: &'a TypeCell) -> T;
 
-    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> T;
+    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>, lookup: &'a TypeCell)
+    -> T;
 
     fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> T;
 
     fn visit_create_array(
         &mut self,
-        array_type: &'a Token,
+        array_type: &'a TypeCell,
         array_size: &'a Option<Rc<Expr>>,
         fields: &'a [Rc<Expr>],
     ) -> T;
 
-    fn visit_create_struct(&mut self, struct_name: &'a Token, fields: &'a [(Token, Rc<Expr>)])
-    -> T;
+    fn visit_create_struct(
+        &mut self,
+        struct_name: &'a TypeCell,
+        fields: &'a [(Identifier, Rc<Expr>)],
+    ) -> T;
 
     fn visit_if(
         &mut self,
         condition: &'a Rc<Expr>,
         if_branch: &'a Rc<Stmt>,
         else_branch: &'a Option<Rc<Stmt>>,
+        expression_result: &'a TypeCell,
     ) -> T;
 
     fn visit_literal(&mut self, value: &'a Token) -> T;
 
-    fn visit_variable(&mut self, name: &'a Token) -> T;
+    fn visit_variable(&mut self, name: &'a Identifier, var_type: &'a TypeCell) -> T;
 }
 
 #[derive(Debug)]
@@ -116,8 +167,8 @@ pub enum Stmt {
         statements: Vec<Rc<Stmt>>,
     },
     Let {
-        name: Token,
-        var_type: Option<Token>,
+        name: Identifier,
+        var_type: TypeCell,
         initializer: Expr,
     },
     Return {
@@ -163,8 +214,8 @@ pub trait StmtVisitor<'a, T> {
 
     fn visit_let(
         &mut self,
-        name: &'a Token,
-        var_type: &'a Option<Token>,
+        name: &'a Identifier,
+        var_type: &'a TypeCell,
         initializer: &'a Expr,
     ) -> T;
 
@@ -189,19 +240,20 @@ pub trait StmtVisitor<'a, T> {
 pub enum Decl {
     Import(Token),
     Struct {
-        name: Token,
-        fields: Vec<(Token, Token)>,
+        name: Identifier,
+        fields: Vec<(Identifier, TypeCell)>,
         methods: Vec<Rc<Decl>>,
     },
     Function {
-        name: Token,
-        return_type: Option<Token>,
-        params: Vec<(Token, Token)>,
+        name: Identifier,
+        return_type: TypeCell,
+        params: Vec<(Identifier, TypeCell)>,
         body: Vec<Stmt>,
+        is_extern: bool,
     },
     Const {
-        name: Token,
-        var_type: Token,
+        name: Identifier,
+        var_type: TypeCell,
         initializer: Expr,
     },
 }
@@ -220,7 +272,8 @@ pub trait DeclVisitor<'a, T> {
                 return_type,
                 params,
                 body,
-            } => self.visit_function(name, return_type, params, body),
+                is_extern,
+            } => self.visit_function(name, return_type, params, body, *is_extern),
             Decl::Const {
                 name,
                 var_type,
@@ -233,18 +286,24 @@ pub trait DeclVisitor<'a, T> {
 
     fn visit_struct(
         &mut self,
-        name: &'a Token,
-        fields: &'a [(Token, Token)],
+        name: &'a Identifier,
+        fields: &'a [(Identifier, TypeCell)],
         methods: &'a [Rc<Decl>],
     ) -> T;
 
     fn visit_function(
         &mut self,
-        name: &'a Token,
-        return_type: &'a Option<Token>,
-        params: &'a [(Token, Token)],
+        name: &'a Identifier,
+        return_type: &'a TypeCell,
+        params: &'a [(Identifier, TypeCell)],
         body: &'a [Stmt],
+        is_extern: bool,
     ) -> T;
 
-    fn visit_const(&mut self, name: &'a Token, var_type: &'a Token, initializer: &'a Expr) -> T;
+    fn visit_const(
+        &mut self,
+        name: &'a Identifier,
+        var_type: &'a TypeCell,
+        initializer: &'a Expr,
+    ) -> T;
 }

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -4,57 +4,111 @@ use crate::{
     lexer::{Token, TokenType},
     typing::{TypeCell, TypeDef},
 };
-use std::{fs::File, io::Error, io::prelude::*, path::PathBuf, rc::Rc};
+use std::{
+    fmt::{self, Display, Formatter},
+    fs::File,
+    io::Error,
+    io::prelude::*,
+    ops::Deref,
+    path::PathBuf,
+    rc::Rc,
+};
 
-pub fn to_cpp_type<'a>(type_def: &TypeDef) -> String {
-    match type_def {
-        TypeDef::Struct { name, members: _ } => format!("{}*", name),
-        TypeDef::Function {
-            parameters: _,
-            return_type: _,
-        } => todo!(),
-        TypeDef::Array(name) => format!("{}*", to_cpp_type(name)),
-        TypeDef::Lazy(name) => panic!("lazy '{}' should have been deref", name),
-        TypeDef::Number {
-            name,
-            size: _,
-            float: _,
-            signed: _,
-        } => String::from(match *name {
-            "i8" => "char",
-            "i16" => "short",
-            "i32" => "int",
-            "i64" => "long",
-            "u8" => "unsigned char",
-            "u16" => "unsigned short",
-            "u32" => "unsigned int",
-            "u64" => "unsigned long",
-            "f32" => "float",
-            "f64" => "double",
-            _ => panic!(),
-        }),
-        TypeDef::Native(name) => String::from(match *name {
-            "str" => "char*",
-            "bool" => "int",
-            "void" => "void",
-            _ => panic!(),
-        }),
-        TypeDef::Module {
-            types: _,
-            fields: _,
-        }
-        | TypeDef::Unknown => panic!(),
+#[derive(Default, Debug)]
+struct CppSourceCode(String);
+
+impl Display for CppSourceCode {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(formatter, "{}", self.0)
     }
 }
 
-pub fn patch_cpp_name(name: &str) -> &str {
-    match name {
-        "self" => "this",
-        "this" => "$this",
-        "new" => "$new",
-        "yield" => "$yield",
-        _ => name,
+impl From<&TypeDef> for CppSourceCode {
+    fn from(type_def: &TypeDef) -> Self {
+        CppSourceCode(match type_def {
+            TypeDef::Struct { name, members: _ } => format!("{}*", name),
+            TypeDef::Function {
+                parameters: _,
+                return_type: _,
+            } => todo!(),
+            TypeDef::Array(name) => format!("{}*", CppSourceCode::from(name.as_ref())),
+            TypeDef::Lazy(name) => panic!("lazy '{}' should have been deref", name),
+            TypeDef::Number {
+                name,
+                size: _,
+                float: _,
+                signed: _,
+            } => String::from(match *name {
+                "i8" => "char",
+                "i16" => "short",
+                "i32" => "int",
+                "i64" => "long",
+                "u8" => "unsigned char",
+                "u16" => "unsigned short",
+                "u32" => "unsigned int",
+                "u64" => "unsigned long",
+                "f32" => "float",
+                "f64" => "double",
+                _ => panic!(),
+            }),
+            TypeDef::Native(name) => String::from(match *name {
+                "str" => "char*",
+                "bool" => "int",
+                "void" => "void",
+                _ => panic!(),
+            }),
+            TypeDef::Module {
+                types: _,
+                fields: _,
+            }
+            | TypeDef::Unknown => panic!(),
+        })
     }
+}
+
+impl From<&TypeCell> for CppSourceCode {
+    fn from(type_cell: &TypeCell) -> Self {
+        CppSourceCode::from(type_cell.borrow().as_ref())
+    }
+}
+
+impl From<&Identifier> for CppSourceCode {
+    fn from(identifier: &Identifier) -> Self {
+        CppSourceCode(
+            match identifier.get_name() {
+                "self" => "this",
+                "this" => "$this",
+                "new" => "$new",
+                "yield" => "$yield",
+                name => name,
+            }
+            .to_string(),
+        )
+    }
+}
+
+impl From<&(Identifier, TypeCell)> for CppSourceCode {
+    fn from((name, type_cell): &(Identifier, TypeCell)) -> Self {
+        CppSourceCode(format!("{} {name}", CppSourceCode::from(type_cell)))
+    }
+}
+
+impl From<String> for CppSourceCode {
+    fn from(string: String) -> Self {
+        CppSourceCode(string)
+    }
+}
+
+fn visit_vec<T, F>(params: &[T], f: F, j: &str) -> CppSourceCode
+where
+    F: FnMut(&T) -> String,
+{
+    params
+        .into_iter()
+        .map(f)
+        .collect::<Vec<String>>()
+        .join(j)
+        .into()
 }
 
 pub struct CppHeaderGenerator;
@@ -65,70 +119,45 @@ impl<'a> CppHeaderGenerator {
         name: &Identifier,
         return_type: &TypeCell,
         params: &[(Identifier, TypeCell)],
-    ) -> String {
-        let mut builder = String::from("\n\t");
-        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(patch_cpp_name(name.get_name()));
-        builder.push_str("(");
-        let mut first = true;
-        for (param_name, param_type) in params {
-            if !first {
-                builder.push_str(", ");
-            } else {
-                first = false;
-            }
-            builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
-            builder.push_str(" ");
-            builder.push_str(param_name.get_name());
-        }
-        builder.push_str(");\n");
-        builder
+    ) -> CppSourceCode {
+        let return_type = CppSourceCode::from(return_type.borrow().as_ref());
+        let name = CppSourceCode::from(name);
+        let params = visit_vec(params, |x| format!("{}", CppSourceCode::from(x)), ", ");
+        CppSourceCode(format!("{return_type} {name}({params});"))
     }
 }
 
 impl<'a> Generator<'a> for CppHeaderGenerator {
-    fn generate(&mut self, declarations: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
+    fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
         let mut file = File::create(output)?;
-        let mut builder = String::with_capacity(255);
-
-        let file_name = output.file_name().expect("expect path has filename");
-        let os_str = file_name.to_ascii_uppercase();
-        let makro_name = os_str
+        let mut path_buf = output.clone();
+        path_buf.set_extension("");
+        let module_name = path_buf
+            .file_name()
+            .expect("expect path has filename")
             .to_str()
             .expect("expect filename is UTF-8")
-            .replace(".", "_");
-        let module_name = file_name
-            .to_str()
-            .expect("expect filename is UTF-8")
-            .replace(".hpp", "")
-            .replace("/", "_");
+            .replace(".", "_")
+            .replace("/", "$");
+        let makro_name = module_name.to_uppercase();
 
-        for decl in declarations {
-            builder.push_str(&self.visit_decl(decl));
-        }
+        let declarations = visit_vec(ast, |x| format!("{}", self.visit_decl(x)), "\n");
+
         write!(
             file,
-            "#ifndef {}\n#define {} 1\n\nnamespace {} {{\n{}\n}}\n#endif",
-            makro_name, makro_name, module_name, builder
+            "#ifndef {makro_name}\n#define {makro_name} 1\nnamespace {module_name} {{\n{declarations}\n}}\n#endif\n"
         )
     }
 }
 
-impl DeclVisitor<'_, String> for CppHeaderGenerator {
-    fn visit_import(&mut self, path: &[Identifier]) -> String {
-        let mut builder = String::from("#include <");
-        let mut first = true;
-        for name in path {
-            if first {
-                first = false;
-            } else {
-                builder.push_str("/");
-            }
-            builder.push_str(name.get_name());
-        }
-        builder.push_str(".hpp>\n");
-        builder
+impl DeclVisitor<'_, CppSourceCode> for CppHeaderGenerator {
+    fn visit_import(&mut self, path: &[Identifier]) -> CppSourceCode {
+        let path = path
+            .into_iter()
+            .map(|x| format!("{x}"))
+            .collect::<Vec<String>>()
+            .join("/");
+        CppSourceCode(format!("#include <{path}.hpp>"))
     }
 
     fn visit_struct(
@@ -136,33 +165,28 @@ impl DeclVisitor<'_, String> for CppHeaderGenerator {
         name: &Identifier,
         fields: &[(Identifier, TypeCell)],
         methods: &[Rc<Decl>],
-    ) -> String {
-        let mut builder = String::from("\nclass ");
-        builder.push_str(patch_cpp_name(name.get_name()));
-        builder.push_str(" {\n  public:\n");
-        for (field_name, field_type) in fields {
-            builder.push_str("\t");
-            builder.push_str(&to_cpp_type(field_type.borrow().as_ref()));
-            builder.push_str(" ");
-            builder.push_str(field_name.get_name());
-            builder.push_str(";\n");
-        }
-        for method in methods {
-            if let Decl::Function {
-                name,
-                return_type,
-                params,
-                body: _,
-                is_extern: _,
-            } = &**method
-            {
-                builder.push_str(&self.visit_method(name, return_type, params));
-            } else {
-                panic!("expected method");
-            }
-        }
-        builder.push_str("};\n");
-        builder
+    ) -> CppSourceCode {
+        let name = CppSourceCode::from(name);
+        let fields = visit_vec(fields, |x| format!("  {};", CppSourceCode::from(x)), "\n");
+        let methods = visit_vec(
+            methods,
+            |decl| {
+                if let Decl::Function {
+                    name,
+                    return_type,
+                    params,
+                    body: _,
+                    is_extern: _,
+                } = decl.as_ref()
+                {
+                    format!("  {}", self.visit_method(name, return_type, params))
+                } else {
+                    panic!()
+                }
+            },
+            "\n",
+        );
+        format!("class {name} {{\npublic:\n{fields}\n{methods}\n}};").into()
     }
 
     fn visit_function(
@@ -172,126 +196,65 @@ impl DeclVisitor<'_, String> for CppHeaderGenerator {
         params: &[(Identifier, TypeCell)],
         _: &[Stmt],
         is_extern: bool,
-    ) -> String {
-        let mut builder = String::from("\nextern ");
-        if is_extern {
-            builder.push_str("\"C\" ")
-        }
-        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(patch_cpp_name(name.get_name()));
-        builder.push_str("(");
-        if params.len() > 0 {
-            let (first_name, first_type) = params.get(0).unwrap();
-            builder.push_str(&to_cpp_type(first_type.borrow().as_ref()));
-            builder.push_str(" ");
-            builder.push_str(first_name.get_name());
-            for (param_name, param_type) in &params[1..] {
-                builder.push_str(", ");
-                builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
-                builder.push_str(" ");
-                builder.push_str(param_name.get_name());
-            }
-        }
-        builder.push_str(");\n");
-        builder
+    ) -> CppSourceCode {
+        let name = CppSourceCode::from(name);
+        let is_extern = if is_extern { "\"C\" " } else { "" };
+        let return_type = CppSourceCode::from(return_type.borrow().as_ref());
+        let params = visit_vec(params, |x| format!("{}", CppSourceCode::from(x)), ", ");
+        CppSourceCode(format!("extern {is_extern}{return_type} {name}({params});"))
     }
 
-    fn visit_const(&mut self, name: &Identifier, var_type: &TypeCell, _: &Expr) -> String {
-        let mut builder = String::from("\nextern ");
-        builder.push_str(&to_cpp_type(var_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(name.get_name());
-        builder.push_str(";\n");
-        builder
+    fn visit_const(
+        &mut self,
+        var_name: &Identifier,
+        var_type: &TypeCell,
+        _: &Expr,
+    ) -> CppSourceCode {
+        let var_name = CppSourceCode::from(var_name);
+        let var_type = CppSourceCode::from(var_type.borrow().as_ref());
+        format!("extern {var_type} {var_name};").into()
     }
 }
 
 pub struct CppCodeGenerator {
-    intendation: usize,
     main_type: Option<Rc<TypeDef>>,
 }
 
 impl<'a> CppCodeGenerator {
     pub fn new() -> CppCodeGenerator {
-        CppCodeGenerator {
-            intendation: 0,
-            main_type: None,
-        }
+        CppCodeGenerator { main_type: None }
     }
 
-    fn begin_scope(&mut self) {
-        self.intendation += 1;
-    }
-
-    fn end_scope(&mut self) {
-        self.intendation -= 1;
-    }
-
-    fn generate_main(return_type: Rc<TypeDef>, module_name: &str) -> String {
-        let mut builder = String::from("int main() {\n");
-        let return_type = to_cpp_type(return_type.as_ref());
-        if return_type == "void" {
-            builder.push_str(module_name);
-            builder.push_str("::main();\n");
-            builder.push_str("return 0;\n")
-        } else if return_type == "int" {
-            builder.push_str("return ");
-            builder.push_str(module_name);
-            builder.push_str("::main();\n")
-        } else {
-            panic!("unsupported return type")
-        }
-        builder.push_str("}");
-        builder
+    fn visit_main(&self, return_type: Rc<TypeDef>, module_name: &str) -> CppSourceCode {
+        let return_type = CppSourceCode::from(return_type.as_ref());
+        let body = match (return_type.0).deref() {
+            "void" => format!("{module_name}::main();\nreturn 0;\n"),
+            "int" => format!("return {module_name}::main();\n"),
+            _ => panic!("unsupported return type"),
+        };
+        format!("int main() {{\n{body}}}\n").into()
     }
 
     fn visit_method(
         &mut self,
-        self_type: &Identifier,
+        struct_name: &Identifier,
         name: &Identifier,
         return_type: &TypeCell,
         params: &[(Identifier, TypeCell)],
         body: &'a [Stmt],
-        is_extern: bool,
-    ) -> String {
-        let mut builder = String::with_capacity(255);
-        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(patch_cpp_name(self_type.get_name()));
-        builder.push_str("::");
-        builder.push_str(name.get_name());
-        builder.push_str("(");
-        let mut first = true;
-        for (param_name, param_type) in params {
-            if !first {
-                builder.push_str(", ");
-            } else {
-                first = false;
-            }
-            builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
-            builder.push_str(" ");
-            builder.push_str(param_name.get_name());
-        }
-        builder.push_str(")");
-        if is_extern {
-            builder.push_str(";\n")
-        } else {
-            self.begin_scope();
-            builder.push_str(" {\n");
-            for stmt in body {
-                builder.push_str(&self.visit_stmt(stmt));
-            }
-            builder.push_str("}\n");
-            self.end_scope();
-        }
-        builder
+        _: bool,
+    ) -> CppSourceCode {
+        let struct_name = CppSourceCode::from(struct_name);
+        let name = CppSourceCode::from(name);
+        let return_type = CppSourceCode::from(return_type);
+        let params = visit_vec(params, |x| format!("{}", CppSourceCode::from(x)), ", ");
+        let body = visit_vec(body, |stmt| format!("{}", self.visit_stmt(stmt)), "\n");
+        format!("{return_type} {struct_name}::{name}({params}) {{\n{body}\n}}").into()
     }
 }
 
 impl<'a> Generator<'a> for CppCodeGenerator {
     fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
-        let mut builder = String::with_capacity(255);
         let mut file = File::create(output)?;
         let mut path_buf = output.clone();
         path_buf.set_extension("hpp");
@@ -302,29 +265,29 @@ impl<'a> Generator<'a> for CppCodeGenerator {
             .expect("expect filename is UTF-8");
         let module_name = header_file.replace(".hpp", "").replace(".", "_");
 
-        builder.push_str("namespace ");
-        builder.push_str(&module_name);
-        builder.push_str(" {\n");
-        for decl in ast {
-            builder.push_str(&self.visit_decl(decl));
-        }
-        builder.push_str("}\n");
-        if let Some(main_type) = &self.main_type {
-            builder.push_str(&Self::generate_main(main_type.clone(), &module_name));
-        }
+        let declarations = visit_vec(ast, |decl| format!("{}", self.visit_decl(decl)), "\n");
+        let main_function = if let Some(return_type) = &self.main_type {
+            self.visit_main(return_type.clone(), &module_name)
+        } else {
+            CppSourceCode::default()
+        };
 
-        write!(file, "#include \"{}\"\n{}", header_file, builder)
+        write!(
+            file,
+            "#include \"{header_file}\"\nnamespace {module_name} {{\n{declarations}\n}}\n{main_function}"
+        )
     }
 }
 
-impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
-    fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> String {
+impl<'a> ExprVisitor<'a, CppSourceCode> for CppCodeGenerator {
+    fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> CppSourceCode {
         match operator.get_type() {
             TokenType::Add => format!("+{}", self.visit_expr(right)),
             TokenType::Sub => format!("-{}", self.visit_expr(right)),
             TokenType::Not => format!("!{}", self.visit_expr(right)),
             _ => todo!(),
         }
+        .into()
     }
 
     fn visit_binary(
@@ -332,47 +295,37 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
         left: &'a Rc<Expr>,
         operator: &Token,
         right: &'a Rc<Expr>,
-    ) -> String {
+    ) -> CppSourceCode {
         match operator.get_type() {
             TokenType::Add => format!("{} + {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Sub => format!("{} - {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Mul => format!("{} * {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Div => format!("{} / {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Eq => format!("{} == {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Neq => {
-                format!("{} != {}", self.visit_expr(left), self.visit_expr(right))
-            }
+            TokenType::Neq => format!("{} != {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Low => format!("{} < {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Leq => {
-                format!("{} <= {}", self.visit_expr(left), self.visit_expr(right))
-            }
+            TokenType::Leq => format!("{} <= {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Gre => format!("{} > {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Geq => {
-                format!("{} >= {}", self.visit_expr(left), self.visit_expr(right))
-            }
-            TokenType::And => {
-                format!("{} && {}", self.visit_expr(left), self.visit_expr(right))
-            }
+            TokenType::Geq => format!("{} >= {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::And => format!("{} && {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Or => format!("{} || {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Xor => format!("{} | {}", self.visit_expr(left), self.visit_expr(right)),
             TokenType::Set => format!("{} = {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::SetAdd => {
-                format!("{} += {}", self.visit_expr(left), self.visit_expr(right))
-            }
-            TokenType::SetSub => {
-                format!("{} -= {}", self.visit_expr(left), self.visit_expr(right))
-            }
-            TokenType::SetMul => {
-                format!("{} *= {}", self.visit_expr(left), self.visit_expr(right))
-            }
-            TokenType::SetDiv => {
-                format!("{} /= {}", self.visit_expr(left), self.visit_expr(right))
-            }
+            TokenType::SetAdd => format!("{} += {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::SetSub => format!("{} -= {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::SetMul => format!("{} *= {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::SetDiv => format!("{} /= {}", self.visit_expr(left), self.visit_expr(right)),
             _ => todo!("{:?}", operator),
         }
+        .into()
     }
 
-    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &Identifier, lookup: &TypeCell) -> String {
+    fn visit_get(
+        &mut self,
+        left: &'a Rc<Expr>,
+        right: &Identifier,
+        lookup: &TypeCell,
+    ) -> CppSourceCode {
         let left = self.visit_expr(left);
         let right = right.get_name();
         match lookup.borrow().as_ref() {
@@ -389,25 +342,28 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
                 error, left, right
             ),
         }
+        .into()
     }
 
-    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>, _: &TypeCell) -> String {
-        format!("{}[{}]", self.visit_expr(object), self.visit_expr(index))
+    fn visit_index(
+        &mut self,
+        object: &'a Rc<Expr>,
+        index: &'a Rc<Expr>,
+        _: &TypeCell,
+    ) -> CppSourceCode {
+        let object = self.visit_expr(object);
+        let index = self.visit_expr(index);
+        format!("{object}[{index}]").into()
     }
 
-    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> String {
-        let mut builder = self.visit_expr(callee);
-        builder.push_str("(");
-        if arguments.len() > 0 {
-            let first_arg = arguments.get(0).unwrap();
-            builder.push_str(&self.visit_expr(first_arg));
-            for arg in &arguments[1..] {
-                builder.push_str(", ");
-                builder.push_str(&self.visit_expr(arg));
-            }
-        }
-        builder.push_str(")");
-        builder
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> CppSourceCode {
+        let callee = self.visit_expr(callee);
+        let arguments = arguments
+            .into_iter()
+            .map(|x| format!("{}", self.visit_expr(x)))
+            .collect::<Vec<String>>()
+            .join(", ");
+        format!("{callee}({arguments})").into()
     }
 
     fn visit_create_array(
@@ -415,44 +371,39 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
         array_type: &TypeCell,
         array_size: &Option<Rc<Expr>>,
         fields: &'a [Rc<Expr>],
-    ) -> String {
-        let mut builder = String::from("new ");
-        builder.push_str(&to_cpp_type(array_type.borrow().as_ref()));
-        builder.push_str("[");
-        if let Some(array_size) = array_size {
-            builder.push_str(&self.visit_expr(array_size));
-        }
-        builder.push_str("]");
-        builder.push_str("{");
-        for field in fields {
-            builder.push_str(&self.visit_expr(field));
-            builder.push_str(", ");
-        }
-        builder.push_str("}");
-        builder
+    ) -> CppSourceCode {
+        let array_type = CppSourceCode::from(array_type);
+        let array_size = array_size
+            .as_ref()
+            .map(|expr| self.visit_expr(expr.as_ref()))
+            .unwrap_or_default();
+        let fields = visit_vec(fields, |x| format!("{}", self.visit_expr(x)), ", ");
+        format!("new {array_type}[{array_size}]{{{fields}}}").into()
     }
 
     fn visit_create_struct(
         &mut self,
         struct_type: &TypeCell,
         fields: &'a [(Identifier, Rc<Expr>)],
-    ) -> String {
-        let mut builder = String::from("new ");
-        if let TypeDef::Struct { name, members: _ } = struct_type.borrow().as_ref() {
-            builder.push_str(name.get_name());
+    ) -> CppSourceCode {
+        let struct_type = struct_type.borrow();
+        let struct_type = if let TypeDef::Struct { name, members: _ } = struct_type.as_ref() {
+            name.get_name()
         } else {
-            panic!("expected created type is a struct");
-        }
-        builder.push_str(" {");
-        for (field_name, field_init) in fields {
-            builder.push_str(".");
-            builder.push_str(field_name.get_name());
-            builder.push_str(" = ");
-            builder.push_str(&self.visit_expr(field_init));
-            builder.push_str(", ")
-        }
-        builder.push_str("}");
-        builder
+            unreachable!()
+        };
+        let fields = visit_vec(
+            fields,
+            |(field_name, field_init)| {
+                format!(
+                    ".{} = {}",
+                    CppSourceCode::from(field_name),
+                    self.visit_expr(field_init)
+                )
+            },
+            ", ",
+        );
+        format!("new {struct_type}{{{fields}}}").into()
     }
 
     fn visit_if(
@@ -461,85 +412,48 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
         if_branch: &'a Rc<Stmt>,
         else_branch: &'a Option<Rc<Stmt>>,
         expression_type: &TypeCell,
-    ) -> String {
+    ) -> CppSourceCode {
+        let condition = self.visit_expr(condition);
+        let if_branch = self.visit_stmt(if_branch);
         if let TypeDef::Unknown = expression_type.borrow().as_ref() {
-            let mut builder = String::from("if (");
-            builder.push_str(&self.visit_expr(condition));
-            builder.push_str(") ");
-            builder.push_str(&self.visit_stmt(if_branch));
-            if let Some(branch) = else_branch {
-                builder.push_str("else ");
-                builder.push_str(&self.visit_stmt(branch))
-            }
-            builder
-        } else {
-            let mut builder = String::from("(");
-            builder.push_str(&self.visit_expr(condition));
-            builder.push_str(" ? ");
-            builder.push_str(&self.visit_stmt(if_branch));
-            builder.push_str(" : ");
             let else_branch = else_branch
                 .as_ref()
-                .expect("expected else expression exists");
-            builder.push_str(&self.visit_stmt(else_branch));
-            builder.push_str(")");
-            builder
+                .map(|expr| format!(" else {}", self.visit_stmt(expr.as_ref())))
+                .unwrap_or_default();
+            format!("if ({condition}) {if_branch}{else_branch}").into()
+        } else {
+            let else_branch = self.visit_stmt(
+                else_branch
+                    .as_ref()
+                    .expect("expected else expression exists"),
+            );
+            format!("{condition} ? {if_branch} : {else_branch}").into()
         }
     }
 
-    fn visit_literal(&mut self, value: &Token) -> String {
+    fn visit_literal(&mut self, value: &Token) -> CppSourceCode {
         match value.get_type() {
             TokenType::Bool(value) => value.to_string(),
             TokenType::Number(value) => value.to_string(),
             TokenType::String(content) => format!("\"{}\"", content),
             _ => todo!(),
         }
+        .into()
     }
 
-    fn visit_variable(&mut self, name: &Identifier, _: &TypeCell) -> String {
-        String::from(patch_cpp_name(name.get_name()))
+    fn visit_variable(&mut self, name: &Identifier, _: &TypeCell) -> CppSourceCode {
+        name.into()
     }
 }
 
-impl<'a> StmtVisitor<'a, String> for CppCodeGenerator {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) -> String {
-        let intend = "\t".repeat(self.intendation);
-        match stmt {
-            Stmt::Block { statements } => self.visit_block(statements),
-            Stmt::Let {
-                name,
-                var_type,
-                initializer,
-            } => format!("{}{}", intend, self.visit_let(name, var_type, initializer)),
-            Stmt::Return { value } => format!("{}{}", intend, self.visit_return(value)),
-            Stmt::Break => format!("{}{}", intend, self.visit_break()),
-            Stmt::While { condition, body } => {
-                format!("{}{}", intend, self.visit_while(condition, body))
-            }
-            Stmt::For {
-                initializer,
-                condition,
-                increment,
-                body,
-            } => format!(
-                "{}{}",
-                intend,
-                self.visit_for(initializer, condition, increment, body)
-            ),
-            Stmt::ExprStmt(expr) => format!("{}{}", intend, self.visit_expr_stmt(expr)),
-        }
-    }
-
-    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> String {
-        let mut builder = String::from("{\n");
-        self.begin_scope();
-        for stmt in statements {
-            builder.push_str(&self.visit_stmt(stmt));
-        }
-        self.end_scope();
-        builder.push_str(&"\t".repeat(self.intendation));
-        builder.push_str("}");
-        builder
+impl<'a> StmtVisitor<'a, CppSourceCode> for CppCodeGenerator {
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> CppSourceCode {
+        let statements = visit_vec(
+            statements,
+            |stmt| format!("{}", self.visit_stmt(stmt)),
+            "\n",
+        );
+        format!("{{\n{statements}\n}}").into()
     }
 
     fn visit_let(
@@ -547,35 +461,26 @@ impl<'a> StmtVisitor<'a, String> for CppCodeGenerator {
         name: &Identifier,
         var_type: &TypeCell,
         initializer: &'a Expr,
-    ) -> String {
-        let mut builder = String::with_capacity(64);
-        builder.push_str(&to_cpp_type(var_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(patch_cpp_name(name.get_name()));
-        builder.push_str(" = ");
-        builder.push_str(&self.visit_expr(initializer));
-        builder.push_str(";\n");
-        builder
+    ) -> CppSourceCode {
+        let name = CppSourceCode::from(name);
+        let var_type = CppSourceCode::from(var_type);
+        let initializer = self.visit_expr(initializer);
+        format!("{var_type} {name} = {initializer};").into()
     }
 
-    fn visit_return(&mut self, value: &'a Expr) -> String {
-        let mut builder = String::from("return ");
-        builder.push_str(&self.visit_expr(value));
-        builder.push_str(";\n");
-        builder
+    fn visit_return(&mut self, value: &'a Expr) -> CppSourceCode {
+        let value = self.visit_expr(value);
+        format!("return {value};").into()
     }
 
-    fn visit_break(&mut self) -> String {
-        String::from("break;\n")
+    fn visit_break(&mut self) -> CppSourceCode {
+        "break;".to_string().into()
     }
 
-    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> String {
-        let mut builder = String::from("while (");
-        builder.push_str(&self.visit_expr(condition));
-        builder.push_str(") ");
-        builder.push_str(&self.visit_stmt(body));
-        builder.push_str("\n");
-        builder
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> CppSourceCode {
+        let condition = self.visit_expr(condition);
+        let body = self.visit_stmt(body);
+        format!("while ({condition}) {body}").into()
     }
 
     fn visit_for(
@@ -584,29 +489,23 @@ impl<'a> StmtVisitor<'a, String> for CppCodeGenerator {
         condition: &'a Expr,
         increment: &'a Expr,
         body: &'a Rc<Stmt>,
-    ) -> String {
-        self.begin_scope();
-        let mut builder = String::from("for (");
-        builder.push_str(&self.visit_stmt(initializer));
-        builder.push_str(&self.visit_expr(condition));
-        builder.push_str(";");
-        builder.push_str(&self.visit_expr(increment));
-        builder.push_str(") ");
-        builder.push_str(&self.visit_stmt(body));
-        self.end_scope();
-        builder
+    ) -> CppSourceCode {
+        let initializer = self.visit_stmt(initializer);
+        let condition = self.visit_expr(condition);
+        let increment = self.visit_expr(increment);
+        let body = self.visit_stmt(body);
+        format!("for ({initializer}; {condition}; {increment}) {body}").into()
     }
 
-    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> String {
-        let mut builder = self.visit_expr(expr);
-        builder.push_str(";\n");
-        builder
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> CppSourceCode {
+        let expr = self.visit_expr(expr);
+        format!("{expr};").into()
     }
 }
 
-impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
-    fn visit_import(&mut self, _: &[Identifier]) -> String {
-        String::new()
+impl<'a> DeclVisitor<'a, CppSourceCode> for CppCodeGenerator {
+    fn visit_import(&mut self, _: &[Identifier]) -> CppSourceCode {
+        CppSourceCode::default()
     }
 
     fn visit_struct(
@@ -614,31 +513,34 @@ impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
         name: &Identifier,
         _: &[(Identifier, TypeCell)],
         methods: &'a [Rc<Decl>],
-    ) -> String {
-        let mut builder = String::with_capacity(255);
-        let self_type = name;
-        for method in methods {
-            if let Decl::Function {
-                name,
-                return_type,
-                params,
-                body,
-                is_extern,
-            } = method.as_ref()
-            {
-                builder.push_str(&self.visit_method(
-                    self_type,
+    ) -> CppSourceCode {
+        let struct_type = name;
+        visit_vec(
+            methods,
+            |method| {
+                if let Decl::Function {
+                    name,
+                    return_type,
+                    params,
+                    body,
+                    is_extern,
+                } = method.as_ref()
+                {
+                    format!("{}", self.visit_method(
+                    struct_type,
                     name,
                     return_type,
                     params,
                     body,
                     *is_extern,
                 ))
-            } else {
-                panic!("expected method")
-            }
-        }
-        builder
+                } else {
+                    panic!("expected method")
+                }
+            },
+            "\n",
+        )
+        .into()
     }
 
     fn visit_function(
@@ -648,40 +550,18 @@ impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
         params: &[(Identifier, TypeCell)],
         body: &'_ [Stmt],
         is_extern: bool,
-    ) -> String {
+    ) -> CppSourceCode {
         if name.get_name() == "main" {
             self.main_type = Some(return_type.borrow().clone())
         }
         if is_extern {
-            return String::new();
+            return CppSourceCode::default();
         }
-
-        let mut builder = String::with_capacity(255);
-        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(patch_cpp_name(name.get_name()));
-        builder.push_str("(");
-        if params.len() > 0 {
-            let (first_name, first_type) = params.get(0).unwrap();
-            builder.push_str(&to_cpp_type(first_type.borrow().as_ref()));
-            builder.push_str(" ");
-            builder.push_str(first_name.get_name());
-            for (param_name, param_type) in &params[1..] {
-                builder.push_str(", ");
-                builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
-                builder.push_str(" ");
-                builder.push_str(param_name.get_name());
-            }
-        }
-        builder.push_str(")");
-        self.begin_scope();
-        builder.push_str(" {\n");
-        for stmt in body {
-            builder.push_str(&self.visit_stmt(stmt));
-        }
-        builder.push_str("}\n");
-        self.end_scope();
-        builder
+        let name = CppSourceCode::from(name);
+        let return_type = CppSourceCode::from(return_type);
+        let params = visit_vec(params, |x| format!("{}", CppSourceCode::from(x)), ", ");
+        let body = visit_vec(body, |x| format!("{}", self.visit_stmt(x)), "\n");
+        format!("{return_type} {name} ({params}) {{\n{body}\n}}").into()
     }
 
     fn visit_const(
@@ -689,13 +569,10 @@ impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
         name: &Identifier,
         var_type: &TypeCell,
         initializer: &'_ Expr,
-    ) -> String {
-        let mut builder = String::from(&to_cpp_type(var_type.borrow().as_ref()));
-        builder.push_str(" ");
-        builder.push_str(name.get_name());
-        builder.push_str(" = ");
-        builder.push_str(&self.visit_expr(initializer));
-        builder.push_str(";\n");
-        builder
+    ) -> CppSourceCode {
+        let name = CppSourceCode::from(name);
+        let var_type = CppSourceCode::from(var_type);
+        let initializer = self.visit_expr(initializer);
+        format!("{var_type} {name} = {initializer};").into()
     }
 }

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -9,7 +9,6 @@ use std::{
     fs::File,
     io::{Error, prelude::*},
     ops::Deref,
-    path::PathBuf,
     rc::Rc,
 };
 
@@ -122,9 +121,9 @@ impl CppHeaderGenerator {
 }
 
 impl<'a> Generator<'a> for CppHeaderGenerator {
-    fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
+    fn generate(&mut self, ast: &'a [Decl], output: &std::path::Path) -> Result<(), Error> {
         let mut file = File::create(output)?;
-        let mut path_buf = output.clone();
+        let mut path_buf = output.to_path_buf();
         path_buf.set_extension("");
         let module_name = path_buf
             .file_name()
@@ -248,9 +247,9 @@ impl<'a> CppCodeGenerator {
 }
 
 impl<'a> Generator<'a> for CppCodeGenerator {
-    fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
+    fn generate(&mut self, ast: &'a [Decl], output: &std::path::Path) -> Result<(), Error> {
         let mut file = File::create(output)?;
-        let mut path_buf = output.clone();
+        let mut path_buf = output.to_path_buf();
         path_buf.set_extension("hpp");
         let header_file = path_buf
             .file_name()

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -7,8 +7,7 @@ use crate::{
 use std::{
     fmt::{self, Display, Formatter},
     fs::File,
-    io::Error,
-    io::prelude::*,
+    io::{Error, prelude::*},
     ops::Deref,
     path::PathBuf,
     rc::Rc,
@@ -103,17 +102,12 @@ fn visit_vec<T, F>(params: &[T], f: F, j: &str) -> CppSourceCode
 where
     F: FnMut(&T) -> String,
 {
-    params
-        .into_iter()
-        .map(f)
-        .collect::<Vec<String>>()
-        .join(j)
-        .into()
+    params.iter().map(f).collect::<Vec<String>>().join(j).into()
 }
 
 pub struct CppHeaderGenerator;
 
-impl<'a> CppHeaderGenerator {
+impl CppHeaderGenerator {
     fn visit_method(
         &mut self,
         name: &Identifier,
@@ -153,7 +147,7 @@ impl<'a> Generator<'a> for CppHeaderGenerator {
 impl DeclVisitor<'_, CppSourceCode> for CppHeaderGenerator {
     fn visit_import(&mut self, path: &[Identifier]) -> CppSourceCode {
         let path = path
-            .into_iter()
+            .iter()
             .map(|x| format!("{x}"))
             .collect::<Vec<String>>()
             .join("/");
@@ -296,25 +290,27 @@ impl<'a> ExprVisitor<'a, CppSourceCode> for CppCodeGenerator {
         operator: &Token,
         right: &'a Rc<Expr>,
     ) -> CppSourceCode {
+        let mut render_op =
+            |op: &str| format!("{} {op} {}", self.visit_expr(left), self.visit_expr(right));
         match operator.get_type() {
-            TokenType::Add => format!("{} + {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Sub => format!("{} - {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Mul => format!("{} * {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Div => format!("{} / {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Eq => format!("{} == {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Neq => format!("{} != {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Low => format!("{} < {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Leq => format!("{} <= {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Gre => format!("{} > {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Geq => format!("{} >= {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::And => format!("{} && {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Or => format!("{} || {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Xor => format!("{} | {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::Set => format!("{} = {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::SetAdd => format!("{} += {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::SetSub => format!("{} -= {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::SetMul => format!("{} *= {}", self.visit_expr(left), self.visit_expr(right)),
-            TokenType::SetDiv => format!("{} /= {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Add => render_op("+"),
+            TokenType::Sub => render_op("-"),
+            TokenType::Mul => render_op("*"),
+            TokenType::Div => render_op("/"),
+            TokenType::Eq => render_op("=="),
+            TokenType::Neq => render_op("!="),
+            TokenType::Low => render_op("<"),
+            TokenType::Leq => render_op("<="),
+            TokenType::Gre => render_op(">"),
+            TokenType::Geq => render_op(">="),
+            TokenType::And => render_op("&&"),
+            TokenType::Or => render_op("||"),
+            TokenType::Xor => render_op("|"),
+            TokenType::Set => render_op("="),
+            TokenType::SetAdd => render_op("+="),
+            TokenType::SetSub => render_op("-="),
+            TokenType::SetMul => render_op("*="),
+            TokenType::SetDiv => render_op("/="),
             _ => todo!("{:?}", operator),
         }
         .into()
@@ -359,7 +355,7 @@ impl<'a> ExprVisitor<'a, CppSourceCode> for CppCodeGenerator {
     fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> CppSourceCode {
         let callee = self.visit_expr(callee);
         let arguments = arguments
-            .into_iter()
+            .iter()
             .map(|x| format!("{}", self.visit_expr(x)))
             .collect::<Vec<String>>()
             .join(", ");
@@ -540,7 +536,6 @@ impl<'a> DeclVisitor<'a, CppSourceCode> for CppCodeGenerator {
             },
             "\n",
         )
-        .into()
     }
 
     fn visit_function(

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -2,8 +2,7 @@ use crate::{
     ast::{Decl, DeclVisitor, Expr, ExprVisitor, Identifier, Stmt, StmtVisitor},
     compiler::Generator,
     lexer::{Token, TokenType},
-    typing::TypeCell,
-    typing::TypeDef,
+    typing::{TypeCell, TypeDef},
 };
 use std::{fs::File, io::Error, io::prelude::*, path::PathBuf, rc::Rc};
 
@@ -40,7 +39,11 @@ pub fn to_cpp_type<'a>(type_def: &TypeDef) -> String {
             "void" => "void",
             _ => panic!(),
         }),
-        TypeDef::Unknown => panic!(),
+        TypeDef::Module {
+            types: _,
+            fields: _,
+        }
+        | TypeDef::Unknown => panic!(),
     }
 }
 
@@ -48,6 +51,7 @@ pub fn patch_cpp_name(name: &str) -> &str {
     match name {
         "self" => "this",
         "this" => "$this",
+        "new" => "$new",
         "yield" => "$yield",
         _ => name,
     }
@@ -65,7 +69,7 @@ impl<'a> CppHeaderGenerator {
         let mut builder = String::from("\n\t");
         builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
         builder.push_str(" ");
-        builder.push_str(name.get_name());
+        builder.push_str(patch_cpp_name(name.get_name()));
         builder.push_str("(");
         let mut first = true;
         for (param_name, param_type) in params {
@@ -88,30 +92,41 @@ impl<'a> Generator<'a> for CppHeaderGenerator {
         let mut file = File::create(output)?;
         let mut builder = String::with_capacity(255);
 
-        for decl in declarations {
-            builder.push_str(&self.visit_decl(decl));
-        }
-
-        let os_str = output
-            .file_name()
-            .expect("expect path has filename")
-            .to_ascii_uppercase();
+        let file_name = output.file_name().expect("expect path has filename");
+        let os_str = file_name.to_ascii_uppercase();
         let makro_name = os_str
             .to_str()
             .expect("expect filename is UTF-8")
             .replace(".", "_");
+        let module_name = file_name
+            .to_str()
+            .expect("expect filename is UTF-8")
+            .replace(".hpp", "")
+            .replace("/", "_");
+
+        for decl in declarations {
+            builder.push_str(&self.visit_decl(decl));
+        }
         write!(
             file,
-            "#ifndef {}\n#define {} 1\n\n{}\n#endif",
-            makro_name, makro_name, builder
+            "#ifndef {}\n#define {} 1\n\nnamespace {} {{\n{}\n}}\n#endif",
+            makro_name, makro_name, module_name, builder
         )
     }
 }
 
 impl DeclVisitor<'_, String> for CppHeaderGenerator {
-    fn visit_import(&mut self, name: &Token) -> String {
+    fn visit_import(&mut self, path: &[Identifier]) -> String {
         let mut builder = String::from("#include <");
-        builder.push_str(name.identifier());
+        let mut first = true;
+        for name in path {
+            if first {
+                first = false;
+            } else {
+                builder.push_str("/");
+            }
+            builder.push_str(name.get_name());
+        }
         builder.push_str(".hpp>\n");
         builder
     }
@@ -164,7 +179,7 @@ impl DeclVisitor<'_, String> for CppHeaderGenerator {
         }
         builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
         builder.push_str(" ");
-        builder.push_str(name.get_name());
+        builder.push_str(patch_cpp_name(name.get_name()));
         builder.push_str("(");
         if params.len() > 0 {
             let (first_name, first_type) = params.get(0).unwrap();
@@ -194,11 +209,15 @@ impl DeclVisitor<'_, String> for CppHeaderGenerator {
 
 pub struct CppCodeGenerator {
     intendation: usize,
+    main_type: Option<Rc<TypeDef>>,
 }
 
 impl<'a> CppCodeGenerator {
     pub fn new() -> CppCodeGenerator {
-        CppCodeGenerator { intendation: 0 }
+        CppCodeGenerator {
+            intendation: 0,
+            main_type: None,
+        }
     }
 
     fn begin_scope(&mut self) {
@@ -207,6 +226,24 @@ impl<'a> CppCodeGenerator {
 
     fn end_scope(&mut self) {
         self.intendation -= 1;
+    }
+
+    fn generate_main(return_type: Rc<TypeDef>, module_name: &str) -> String {
+        let mut builder = String::from("int main() {\n");
+        let return_type = to_cpp_type(return_type.as_ref());
+        if return_type == "void" {
+            builder.push_str(module_name);
+            builder.push_str("::main();\n");
+            builder.push_str("return 0;\n")
+        } else if return_type == "int" {
+            builder.push_str("return ");
+            builder.push_str(module_name);
+            builder.push_str("::main();\n")
+        } else {
+            panic!("unsupported return type")
+        }
+        builder.push_str("}");
+        builder
     }
 
     fn visit_method(
@@ -221,7 +258,7 @@ impl<'a> CppCodeGenerator {
         let mut builder = String::with_capacity(255);
         builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
         builder.push_str(" ");
-        builder.push_str(self_type.get_name());
+        builder.push_str(patch_cpp_name(self_type.get_name()));
         builder.push_str("::");
         builder.push_str(name.get_name());
         builder.push_str("(");
@@ -255,10 +292,6 @@ impl<'a> CppCodeGenerator {
 impl<'a> Generator<'a> for CppCodeGenerator {
     fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
         let mut builder = String::with_capacity(255);
-        for decl in ast {
-            builder.push_str(&self.visit_decl(decl));
-        }
-
         let mut file = File::create(output)?;
         let mut path_buf = output.clone();
         path_buf.set_extension("hpp");
@@ -267,7 +300,20 @@ impl<'a> Generator<'a> for CppCodeGenerator {
             .expect("expect path has filename")
             .to_str()
             .expect("expect filename is UTF-8");
-        write!(file, "#include \"{}\"\n\n{}", header_file, builder)
+        let module_name = header_file.replace(".hpp", "").replace(".", "_");
+
+        builder.push_str("namespace ");
+        builder.push_str(&module_name);
+        builder.push_str(" {\n");
+        for decl in ast {
+            builder.push_str(&self.visit_decl(decl));
+        }
+        builder.push_str("}\n");
+        if let Some(main_type) = &self.main_type {
+            builder.push_str(&Self::generate_main(main_type.clone(), &module_name));
+        }
+
+        write!(file, "#include \"{}\"\n{}", header_file, builder)
     }
 }
 
@@ -326,8 +372,23 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
         }
     }
 
-    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &Token, _: &TypeCell) -> String {
-        format!("{}->{}", self.visit_expr(left), right.identifier())
+    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &Identifier, lookup: &TypeCell) -> String {
+        let left = self.visit_expr(left);
+        let right = right.get_name();
+        match lookup.borrow().as_ref() {
+            TypeDef::Struct {
+                name: _,
+                members: _,
+            } => format!("{}->{}", left, right),
+            TypeDef::Module {
+                types: _,
+                fields: _,
+            } => format!("{}::{}", left, right),
+            error => panic!(
+                "can only lookup structs and modules, not {:?} at {:?} with {:?}",
+                error, left, right
+            ),
+        }
     }
 
     fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>, _: &TypeCell) -> String {
@@ -383,7 +444,10 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
             panic!("expected created type is a struct");
         }
         builder.push_str(" {");
-        for (_, field_init) in fields {
+        for (field_name, field_init) in fields {
+            builder.push_str(".");
+            builder.push_str(field_name.get_name());
+            builder.push_str(" = ");
             builder.push_str(&self.visit_expr(field_init));
             builder.push_str(", ")
         }
@@ -398,15 +462,29 @@ impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
         else_branch: &'a Option<Rc<Stmt>>,
         expression_type: &TypeCell,
     ) -> String {
-        let mut builder = String::from("if (");
-        builder.push_str(&self.visit_expr(condition));
-        builder.push_str(") ");
-        builder.push_str(&self.visit_stmt(if_branch));
-        if let Some(branch) = else_branch {
-            builder.push_str("else ");
-            builder.push_str(&self.visit_stmt(branch))
+        if let TypeDef::Unknown = expression_type.borrow().as_ref() {
+            let mut builder = String::from("if (");
+            builder.push_str(&self.visit_expr(condition));
+            builder.push_str(") ");
+            builder.push_str(&self.visit_stmt(if_branch));
+            if let Some(branch) = else_branch {
+                builder.push_str("else ");
+                builder.push_str(&self.visit_stmt(branch))
+            }
+            builder
+        } else {
+            let mut builder = String::from("(");
+            builder.push_str(&self.visit_expr(condition));
+            builder.push_str(" ? ");
+            builder.push_str(&self.visit_stmt(if_branch));
+            builder.push_str(" : ");
+            let else_branch = else_branch
+                .as_ref()
+                .expect("expected else expression exists");
+            builder.push_str(&self.visit_stmt(else_branch));
+            builder.push_str(")");
+            builder
         }
-        builder
     }
 
     fn visit_literal(&mut self, value: &Token) -> String {
@@ -527,8 +605,8 @@ impl<'a> StmtVisitor<'a, String> for CppCodeGenerator {
 }
 
 impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
-    fn visit_import(&mut self, _: &Token) -> String {
-        String::from("")
+    fn visit_import(&mut self, _: &[Identifier]) -> String {
+        String::new()
     }
 
     fn visit_struct(
@@ -571,6 +649,9 @@ impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
         body: &'_ [Stmt],
         is_extern: bool,
     ) -> String {
+        if name.get_name() == "main" {
+            self.main_type = Some(return_type.borrow().clone())
+        }
         if is_extern {
             return String::new();
         }
@@ -578,7 +659,7 @@ impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
         let mut builder = String::with_capacity(255);
         builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
         builder.push_str(" ");
-        builder.push_str(name.get_name());
+        builder.push_str(patch_cpp_name(name.get_name()));
         builder.push_str("(");
         if params.len() > 0 {
             let (first_name, first_type) = params.get(0).unwrap();

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -1,0 +1,620 @@
+use crate::{
+    ast::{Decl, DeclVisitor, Expr, ExprVisitor, Identifier, Stmt, StmtVisitor},
+    compiler::Generator,
+    lexer::{Token, TokenType},
+    typing::TypeCell,
+    typing::TypeDef,
+};
+use std::{fs::File, io::Error, io::prelude::*, path::PathBuf, rc::Rc};
+
+pub fn to_cpp_type<'a>(type_def: &TypeDef) -> String {
+    match type_def {
+        TypeDef::Struct { name, members: _ } => format!("{}*", name),
+        TypeDef::Function {
+            parameters: _,
+            return_type: _,
+        } => todo!(),
+        TypeDef::Array(name) => format!("{}*", to_cpp_type(name)),
+        TypeDef::Lazy(name) => panic!("lazy '{}' should have been deref", name),
+        TypeDef::Number {
+            name,
+            size: _,
+            float: _,
+            signed: _,
+        } => String::from(match *name {
+            "i8" => "char",
+            "i16" => "short",
+            "i32" => "int",
+            "i64" => "long",
+            "u8" => "unsigned char",
+            "u16" => "unsigned short",
+            "u32" => "unsigned int",
+            "u64" => "unsigned long",
+            "f32" => "float",
+            "f64" => "double",
+            _ => panic!(),
+        }),
+        TypeDef::Native(name) => String::from(match *name {
+            "str" => "char*",
+            "bool" => "int",
+            "void" => "void",
+            _ => panic!(),
+        }),
+        TypeDef::Unknown => panic!(),
+    }
+}
+
+pub fn patch_cpp_name(name: &str) -> &str {
+    match name {
+        "self" => "this",
+        "this" => "$this",
+        "yield" => "$yield",
+        _ => name,
+    }
+}
+
+pub struct CppHeaderGenerator;
+
+impl<'a> CppHeaderGenerator {
+    fn visit_method(
+        &mut self,
+        name: &Identifier,
+        return_type: &TypeCell,
+        params: &[(Identifier, TypeCell)],
+    ) -> String {
+        let mut builder = String::from("\n\t");
+        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(name.get_name());
+        builder.push_str("(");
+        let mut first = true;
+        for (param_name, param_type) in params {
+            if !first {
+                builder.push_str(", ");
+            } else {
+                first = false;
+            }
+            builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
+            builder.push_str(" ");
+            builder.push_str(param_name.get_name());
+        }
+        builder.push_str(");\n");
+        builder
+    }
+}
+
+impl<'a> Generator<'a> for CppHeaderGenerator {
+    fn generate(&mut self, declarations: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
+        let mut file = File::create(output)?;
+        let mut builder = String::with_capacity(255);
+
+        for decl in declarations {
+            builder.push_str(&self.visit_decl(decl));
+        }
+
+        let os_str = output
+            .file_name()
+            .expect("expect path has filename")
+            .to_ascii_uppercase();
+        let makro_name = os_str
+            .to_str()
+            .expect("expect filename is UTF-8")
+            .replace(".", "_");
+        write!(
+            file,
+            "#ifndef {}\n#define {} 1\n\n{}\n#endif",
+            makro_name, makro_name, builder
+        )
+    }
+}
+
+impl DeclVisitor<'_, String> for CppHeaderGenerator {
+    fn visit_import(&mut self, name: &Token) -> String {
+        let mut builder = String::from("#include <");
+        builder.push_str(name.identifier());
+        builder.push_str(".hpp>\n");
+        builder
+    }
+
+    fn visit_struct(
+        &mut self,
+        name: &Identifier,
+        fields: &[(Identifier, TypeCell)],
+        methods: &[Rc<Decl>],
+    ) -> String {
+        let mut builder = String::from("\nclass ");
+        builder.push_str(patch_cpp_name(name.get_name()));
+        builder.push_str(" {\n  public:\n");
+        for (field_name, field_type) in fields {
+            builder.push_str("\t");
+            builder.push_str(&to_cpp_type(field_type.borrow().as_ref()));
+            builder.push_str(" ");
+            builder.push_str(field_name.get_name());
+            builder.push_str(";\n");
+        }
+        for method in methods {
+            if let Decl::Function {
+                name,
+                return_type,
+                params,
+                body: _,
+                is_extern: _,
+            } = &**method
+            {
+                builder.push_str(&self.visit_method(name, return_type, params));
+            } else {
+                panic!("expected method");
+            }
+        }
+        builder.push_str("};\n");
+        builder
+    }
+
+    fn visit_function(
+        &mut self,
+        name: &Identifier,
+        return_type: &TypeCell,
+        params: &[(Identifier, TypeCell)],
+        _: &[Stmt],
+        is_extern: bool,
+    ) -> String {
+        let mut builder = String::from("\nextern ");
+        if is_extern {
+            builder.push_str("\"C\" ")
+        }
+        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(name.get_name());
+        builder.push_str("(");
+        if params.len() > 0 {
+            let (first_name, first_type) = params.get(0).unwrap();
+            builder.push_str(&to_cpp_type(first_type.borrow().as_ref()));
+            builder.push_str(" ");
+            builder.push_str(first_name.get_name());
+            for (param_name, param_type) in &params[1..] {
+                builder.push_str(", ");
+                builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
+                builder.push_str(" ");
+                builder.push_str(param_name.get_name());
+            }
+        }
+        builder.push_str(");\n");
+        builder
+    }
+
+    fn visit_const(&mut self, name: &Identifier, var_type: &TypeCell, _: &Expr) -> String {
+        let mut builder = String::from("\nextern ");
+        builder.push_str(&to_cpp_type(var_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(name.get_name());
+        builder.push_str(";\n");
+        builder
+    }
+}
+
+pub struct CppCodeGenerator {
+    intendation: usize,
+}
+
+impl<'a> CppCodeGenerator {
+    pub fn new() -> CppCodeGenerator {
+        CppCodeGenerator { intendation: 0 }
+    }
+
+    fn begin_scope(&mut self) {
+        self.intendation += 1;
+    }
+
+    fn end_scope(&mut self) {
+        self.intendation -= 1;
+    }
+
+    fn visit_method(
+        &mut self,
+        self_type: &Identifier,
+        name: &Identifier,
+        return_type: &TypeCell,
+        params: &[(Identifier, TypeCell)],
+        body: &'a [Stmt],
+        is_extern: bool,
+    ) -> String {
+        let mut builder = String::with_capacity(255);
+        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(self_type.get_name());
+        builder.push_str("::");
+        builder.push_str(name.get_name());
+        builder.push_str("(");
+        let mut first = true;
+        for (param_name, param_type) in params {
+            if !first {
+                builder.push_str(", ");
+            } else {
+                first = false;
+            }
+            builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
+            builder.push_str(" ");
+            builder.push_str(param_name.get_name());
+        }
+        builder.push_str(")");
+        if is_extern {
+            builder.push_str(";\n")
+        } else {
+            self.begin_scope();
+            builder.push_str(" {\n");
+            for stmt in body {
+                builder.push_str(&self.visit_stmt(stmt));
+            }
+            builder.push_str("}\n");
+            self.end_scope();
+        }
+        builder
+    }
+}
+
+impl<'a> Generator<'a> for CppCodeGenerator {
+    fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error> {
+        let mut builder = String::with_capacity(255);
+        for decl in ast {
+            builder.push_str(&self.visit_decl(decl));
+        }
+
+        let mut file = File::create(output)?;
+        let mut path_buf = output.clone();
+        path_buf.set_extension("hpp");
+        let header_file = path_buf
+            .file_name()
+            .expect("expect path has filename")
+            .to_str()
+            .expect("expect filename is UTF-8");
+        write!(file, "#include \"{}\"\n\n{}", header_file, builder)
+    }
+}
+
+impl<'a> ExprVisitor<'a, String> for CppCodeGenerator {
+    fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> String {
+        match operator.get_type() {
+            TokenType::Add => format!("+{}", self.visit_expr(right)),
+            TokenType::Sub => format!("-{}", self.visit_expr(right)),
+            TokenType::Not => format!("!{}", self.visit_expr(right)),
+            _ => todo!(),
+        }
+    }
+
+    fn visit_binary(
+        &mut self,
+        left: &'a Rc<Expr>,
+        operator: &Token,
+        right: &'a Rc<Expr>,
+    ) -> String {
+        match operator.get_type() {
+            TokenType::Add => format!("{} + {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Sub => format!("{} - {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Mul => format!("{} * {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Div => format!("{} / {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Eq => format!("{} == {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Neq => {
+                format!("{} != {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::Low => format!("{} < {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Leq => {
+                format!("{} <= {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::Gre => format!("{} > {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Geq => {
+                format!("{} >= {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::And => {
+                format!("{} && {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::Or => format!("{} || {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Xor => format!("{} | {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::Set => format!("{} = {}", self.visit_expr(left), self.visit_expr(right)),
+            TokenType::SetAdd => {
+                format!("{} += {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::SetSub => {
+                format!("{} -= {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::SetMul => {
+                format!("{} *= {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            TokenType::SetDiv => {
+                format!("{} /= {}", self.visit_expr(left), self.visit_expr(right))
+            }
+            _ => todo!("{:?}", operator),
+        }
+    }
+
+    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &Token, _: &TypeCell) -> String {
+        format!("{}->{}", self.visit_expr(left), right.identifier())
+    }
+
+    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>, _: &TypeCell) -> String {
+        format!("{}[{}]", self.visit_expr(object), self.visit_expr(index))
+    }
+
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> String {
+        let mut builder = self.visit_expr(callee);
+        builder.push_str("(");
+        if arguments.len() > 0 {
+            let first_arg = arguments.get(0).unwrap();
+            builder.push_str(&self.visit_expr(first_arg));
+            for arg in &arguments[1..] {
+                builder.push_str(", ");
+                builder.push_str(&self.visit_expr(arg));
+            }
+        }
+        builder.push_str(")");
+        builder
+    }
+
+    fn visit_create_array(
+        &mut self,
+        array_type: &TypeCell,
+        array_size: &Option<Rc<Expr>>,
+        fields: &'a [Rc<Expr>],
+    ) -> String {
+        let mut builder = String::from("new ");
+        builder.push_str(&to_cpp_type(array_type.borrow().as_ref()));
+        builder.push_str("[");
+        if let Some(array_size) = array_size {
+            builder.push_str(&self.visit_expr(array_size));
+        }
+        builder.push_str("]");
+        builder.push_str("{");
+        for field in fields {
+            builder.push_str(&self.visit_expr(field));
+            builder.push_str(", ");
+        }
+        builder.push_str("}");
+        builder
+    }
+
+    fn visit_create_struct(
+        &mut self,
+        struct_type: &TypeCell,
+        fields: &'a [(Identifier, Rc<Expr>)],
+    ) -> String {
+        let mut builder = String::from("new ");
+        if let TypeDef::Struct { name, members: _ } = struct_type.borrow().as_ref() {
+            builder.push_str(name.get_name());
+        } else {
+            panic!("expected created type is a struct");
+        }
+        builder.push_str(" {");
+        for (_, field_init) in fields {
+            builder.push_str(&self.visit_expr(field_init));
+            builder.push_str(", ")
+        }
+        builder.push_str("}");
+        builder
+    }
+
+    fn visit_if(
+        &mut self,
+        condition: &'a Rc<Expr>,
+        if_branch: &'a Rc<Stmt>,
+        else_branch: &'a Option<Rc<Stmt>>,
+        expression_type: &TypeCell,
+    ) -> String {
+        let mut builder = String::from("if (");
+        builder.push_str(&self.visit_expr(condition));
+        builder.push_str(") ");
+        builder.push_str(&self.visit_stmt(if_branch));
+        if let Some(branch) = else_branch {
+            builder.push_str("else ");
+            builder.push_str(&self.visit_stmt(branch))
+        }
+        builder
+    }
+
+    fn visit_literal(&mut self, value: &Token) -> String {
+        match value.get_type() {
+            TokenType::Bool(value) => value.to_string(),
+            TokenType::Number(value) => value.to_string(),
+            TokenType::String(content) => format!("\"{}\"", content),
+            _ => todo!(),
+        }
+    }
+
+    fn visit_variable(&mut self, name: &Identifier, _: &TypeCell) -> String {
+        String::from(patch_cpp_name(name.get_name()))
+    }
+}
+
+impl<'a> StmtVisitor<'a, String> for CppCodeGenerator {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) -> String {
+        let intend = "\t".repeat(self.intendation);
+        match stmt {
+            Stmt::Block { statements } => self.visit_block(statements),
+            Stmt::Let {
+                name,
+                var_type,
+                initializer,
+            } => format!("{}{}", intend, self.visit_let(name, var_type, initializer)),
+            Stmt::Return { value } => format!("{}{}", intend, self.visit_return(value)),
+            Stmt::Break => format!("{}{}", intend, self.visit_break()),
+            Stmt::While { condition, body } => {
+                format!("{}{}", intend, self.visit_while(condition, body))
+            }
+            Stmt::For {
+                initializer,
+                condition,
+                increment,
+                body,
+            } => format!(
+                "{}{}",
+                intend,
+                self.visit_for(initializer, condition, increment, body)
+            ),
+            Stmt::ExprStmt(expr) => format!("{}{}", intend, self.visit_expr_stmt(expr)),
+        }
+    }
+
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> String {
+        let mut builder = String::from("{\n");
+        self.begin_scope();
+        for stmt in statements {
+            builder.push_str(&self.visit_stmt(stmt));
+        }
+        self.end_scope();
+        builder.push_str(&"\t".repeat(self.intendation));
+        builder.push_str("}");
+        builder
+    }
+
+    fn visit_let(
+        &mut self,
+        name: &Identifier,
+        var_type: &TypeCell,
+        initializer: &'a Expr,
+    ) -> String {
+        let mut builder = String::with_capacity(64);
+        builder.push_str(&to_cpp_type(var_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(patch_cpp_name(name.get_name()));
+        builder.push_str(" = ");
+        builder.push_str(&self.visit_expr(initializer));
+        builder.push_str(";\n");
+        builder
+    }
+
+    fn visit_return(&mut self, value: &'a Expr) -> String {
+        let mut builder = String::from("return ");
+        builder.push_str(&self.visit_expr(value));
+        builder.push_str(";\n");
+        builder
+    }
+
+    fn visit_break(&mut self) -> String {
+        String::from("break;\n")
+    }
+
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> String {
+        let mut builder = String::from("while (");
+        builder.push_str(&self.visit_expr(condition));
+        builder.push_str(") ");
+        builder.push_str(&self.visit_stmt(body));
+        builder.push_str("\n");
+        builder
+    }
+
+    fn visit_for(
+        &mut self,
+        initializer: &'a Rc<Stmt>,
+        condition: &'a Expr,
+        increment: &'a Expr,
+        body: &'a Rc<Stmt>,
+    ) -> String {
+        self.begin_scope();
+        let mut builder = String::from("for (");
+        builder.push_str(&self.visit_stmt(initializer));
+        builder.push_str(&self.visit_expr(condition));
+        builder.push_str(";");
+        builder.push_str(&self.visit_expr(increment));
+        builder.push_str(") ");
+        builder.push_str(&self.visit_stmt(body));
+        self.end_scope();
+        builder
+    }
+
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> String {
+        let mut builder = self.visit_expr(expr);
+        builder.push_str(";\n");
+        builder
+    }
+}
+
+impl<'a> DeclVisitor<'a, String> for CppCodeGenerator {
+    fn visit_import(&mut self, _: &Token) -> String {
+        String::from("")
+    }
+
+    fn visit_struct(
+        &mut self,
+        name: &Identifier,
+        _: &[(Identifier, TypeCell)],
+        methods: &'a [Rc<Decl>],
+    ) -> String {
+        let mut builder = String::with_capacity(255);
+        let self_type = name;
+        for method in methods {
+            if let Decl::Function {
+                name,
+                return_type,
+                params,
+                body,
+                is_extern,
+            } = method.as_ref()
+            {
+                builder.push_str(&self.visit_method(
+                    self_type,
+                    name,
+                    return_type,
+                    params,
+                    body,
+                    *is_extern,
+                ))
+            } else {
+                panic!("expected method")
+            }
+        }
+        builder
+    }
+
+    fn visit_function(
+        &mut self,
+        name: &Identifier,
+        return_type: &TypeCell,
+        params: &[(Identifier, TypeCell)],
+        body: &'_ [Stmt],
+        is_extern: bool,
+    ) -> String {
+        if is_extern {
+            return String::new();
+        }
+
+        let mut builder = String::with_capacity(255);
+        builder.push_str(&to_cpp_type(return_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(name.get_name());
+        builder.push_str("(");
+        if params.len() > 0 {
+            let (first_name, first_type) = params.get(0).unwrap();
+            builder.push_str(&to_cpp_type(first_type.borrow().as_ref()));
+            builder.push_str(" ");
+            builder.push_str(first_name.get_name());
+            for (param_name, param_type) in &params[1..] {
+                builder.push_str(", ");
+                builder.push_str(&to_cpp_type(param_type.borrow().as_ref()));
+                builder.push_str(" ");
+                builder.push_str(param_name.get_name());
+            }
+        }
+        builder.push_str(")");
+        self.begin_scope();
+        builder.push_str(" {\n");
+        for stmt in body {
+            builder.push_str(&self.visit_stmt(stmt));
+        }
+        builder.push_str("}\n");
+        self.end_scope();
+        builder
+    }
+
+    fn visit_const(
+        &mut self,
+        name: &Identifier,
+        var_type: &TypeCell,
+        initializer: &'_ Expr,
+    ) -> String {
+        let mut builder = String::from(&to_cpp_type(var_type.borrow().as_ref()));
+        builder.push_str(" ");
+        builder.push_str(name.get_name());
+        builder.push_str(" = ");
+        builder.push_str(&self.visit_expr(initializer));
+        builder.push_str(";\n");
+        builder
+    }
+}

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,5 +1,8 @@
 use crate::ast::Decl;
-use std::{io::Error, path::PathBuf};
+use std::{
+    io::Error,
+    path::{Path, PathBuf},
+};
 
 pub mod cpp;
 
@@ -10,7 +13,7 @@ pub fn replace_extension(path: &str, new_ext: &str) -> PathBuf {
 }
 
 pub trait Generator<'a> {
-    fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error>;
+    fn generate(&mut self, ast: &'a [Decl], output: &Path) -> Result<(), Error>;
 }
 
 pub struct Compiler<'a> {
@@ -22,11 +25,7 @@ impl<'a> Compiler<'a> {
         Compiler { ast }
     }
 
-    pub fn compile<T: Generator<'a>>(
-        &self,
-        mut generator: T,
-        output: &PathBuf,
-    ) -> Result<(), Error> {
-        generator.generate(&self.ast, output)
+    pub fn compile<T: Generator<'a>>(&self, mut generator: T, output: &Path) -> Result<(), Error> {
+        generator.generate(self.ast, output)
     }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,0 +1,32 @@
+use crate::ast::Decl;
+use std::{io::Error, path::PathBuf};
+
+pub mod cpp;
+
+pub fn replace_extension(path: &str, new_ext: &str) -> PathBuf {
+    let mut path_buf = PathBuf::from(path);
+    path_buf.set_extension(new_ext);
+    path_buf
+}
+
+pub trait Generator<'a> {
+    fn generate(&mut self, ast: &'a [Decl], output: &PathBuf) -> Result<(), Error>;
+}
+
+pub struct Compiler<'a> {
+    ast: &'a [Decl],
+}
+
+impl<'a> Compiler<'a> {
+    pub fn new(ast: &'a [Decl]) -> Compiler<'a> {
+        Compiler { ast }
+    }
+
+    pub fn compile<T: Generator<'a>>(
+        &self,
+        mut generator: T,
+        output: &PathBuf,
+    ) -> Result<(), Error> {
+        generator.generate(&self.ast, output)
+    }
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,264 +1,116 @@
-use std::collections::HashMap;
-use std::fmt::{Display, Formatter, Result};
-use std::rc::Rc;
+use std::{collections::HashMap, rc::Rc};
 
-use crate::ast::{Decl, DeclVisitor, Expr, Stmt};
-use crate::lexer::Token;
+use crate::{
+    ast::{Decl, DeclVisitor, Expr, Identifier, Stmt},
+    lexer::Token,
+    typing::{TypeCell, TypeDef, TypeNames},
+};
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum TypeDef<'a> {
-    Struct {
-        name: &'a str,
-        members: HashMap<&'a str, Rc<TypeDef<'a>>>,
-    },
-    Function {
-        parameters: Vec<Rc<TypeDef<'a>>>,
-        return_type: Rc<TypeDef<'a>>,
-    },
-    Array(Rc<TypeDef<'a>>),
-    Number {
-        name: &'static str,
-        size: u8,
-        float: bool,
-        signed: bool,
-    },
-    Native(&'static str),
-    Lazy(&'a str),
+pub struct Header {
+    types: TypeNames,
+    fields: TypeNames,
 }
 
-impl<'a> TypeDef<'a> {
-    fn make_number(name: &'static str, size: u8, float: bool, signed: bool) -> TypeDef<'a> {
-        Self::Number {
-            name,
-            size,
-            float,
-            signed,
-        }
-    }
-
-    pub fn is_castable_to(&self, to: &Self) -> bool {
-        match self {
-            Self::Number {
-                name: _,
-                size,
-                float,
-                signed: _,
-            } => {
-                let (this_size, this_float) = (size, float);
-                if let Self::Number {
-                    name: _,
-                    size,
-                    float,
-                    signed: _,
-                } = to
-                {
-                    if *this_float {
-                        return *float && this_size <= size;
-                    } else {
-                        return this_size <= size;
-                    }
-                } else {
-                    return false;
-                }
-            }
-            Self::Function {
-                parameters,
-                return_type,
-            } => {
-                let (this_para, this_return) = (parameters, return_type);
-                if let Self::Function {
-                    parameters,
-                    return_type,
-                } = to
-                {
-                    for (par_from, par_to) in this_para.iter().zip(parameters) {
-                        if !par_from.is_castable_to(par_to) {
-                            return false;
-                        }
-                    }
-                    return this_return.is_castable_to(return_type);
-                } else {
-                    return false;
-                }
-            }
-            Self::Struct { name, members: _ } => {
-                let this_name = name;
-                if let TypeDef::Struct { name, members: _ } = to {
-                    return this_name == name;
-                } else {
-                    return false;
-                }
-            }
-            Self::Native(this_name) => {
-                if let Self::Native(name) = to {
-                    return this_name == name;
-                } else {
-                    return false;
-                }
-            }
-            _ => {
-                panic!(
-                    "tried to typecheck the lazy type '{}' that was not dereferenced yet",
-                    self
-                )
-            }
-        }
-    }
-
-    pub fn is_integer(&self) -> bool {
-        if let TypeDef::Number {
-            name: _,
-            size: _,
-            float,
-            signed: _,
-        } = *self
-        {
-            return !float;
-        }
-        false
-    }
-
-    pub fn is_number(&self) -> bool {
-        if let TypeDef::Number {
-            name,
-            size: _,
-            float: _,
-            signed: _,
-        } = *self
-        {
-            return matches!(
-                name,
-                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64"
-            );
-        }
-        false
-    }
-
-    pub fn is_bool(&self) -> bool {
-        if let TypeDef::Native(name) = *self {
-            name == "bool"
-        } else {
-            false
-        }
-    }
-}
-
-impl Display for TypeDef<'_> {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
-        match self {
-            Self::Struct { name, members: _ } => formatter.write_str(name),
-            Self::Function {
-                parameters,
-                return_type,
-            } => write!(formatter, "{:?} -> {}", parameters, return_type),
-            Self::Array(array_type) => write!(formatter, "[{:?}]", array_type),
-            Self::Number {
-                name,
-                size: _,
-                float: _,
-                signed: _,
-            } => formatter.write_str(name),
-            Self::Native(name) => formatter.write_str(name),
-            Self::Lazy(name) => formatter.write_str(name),
-        }
-    }
-}
-
-pub struct Header<'a> {
-    types: HashMap<&'a str, Rc<TypeDef<'a>>>,
-    fields: HashMap<&'a str, Rc<TypeDef<'a>>>,
-}
-
-impl<'a> Header<'a> {
-    pub fn new() -> Header<'a> {
+impl Header {
+    pub fn new() -> Header {
         Header {
             types: HashMap::from([
-                ("u8", Rc::new(TypeDef::make_number("u8", 1, false, false))),
-                ("u16", Rc::new(TypeDef::make_number("u16", 2, false, false))),
-                ("u32", Rc::new(TypeDef::make_number("u32", 4, false, false))),
-                ("u64", Rc::new(TypeDef::make_number("u64", 8, false, false))),
-                ("i8", Rc::new(TypeDef::make_number("i8", 1, false, true))),
-                ("i16", Rc::new(TypeDef::make_number("i16", 2, false, true))),
-                ("i32", Rc::new(TypeDef::make_number("i32", 4, false, true))),
-                ("i64", Rc::new(TypeDef::make_number("i64", 8, false, true))),
-                ("f32", Rc::new(TypeDef::make_number("f32", 4, true, true))),
-                ("f64", Rc::new(TypeDef::make_number("f64", 8, true, true))),
-                ("bool", Rc::new(TypeDef::Native("bool"))),
-                ("char", Rc::new(TypeDef::Native("char"))),
-                ("str", Rc::new(TypeDef::Native("str"))),
-                ("void", Rc::new(TypeDef::Native("void"))),
+                (
+                    "u8".to_string(),
+                    Rc::new(TypeDef::make_number("u8", 1, false, false)),
+                ),
+                (
+                    "u16".to_string(),
+                    Rc::new(TypeDef::make_number("u16", 2, false, false)),
+                ),
+                (
+                    "u32".to_string(),
+                    Rc::new(TypeDef::make_number("u32", 4, false, false)),
+                ),
+                (
+                    "u64".to_string(),
+                    Rc::new(TypeDef::make_number("u64", 8, false, false)),
+                ),
+                (
+                    "i8".to_string(),
+                    Rc::new(TypeDef::make_number("i8", 1, false, true)),
+                ),
+                (
+                    "i16".to_string(),
+                    Rc::new(TypeDef::make_number("i16", 2, false, true)),
+                ),
+                (
+                    "i32".to_string(),
+                    Rc::new(TypeDef::make_number("i32", 4, false, true)),
+                ),
+                (
+                    "i64".to_string(),
+                    Rc::new(TypeDef::make_number("i64", 8, false, true)),
+                ),
+                (
+                    "f32".to_string(),
+                    Rc::new(TypeDef::make_number("f32", 4, true, true)),
+                ),
+                (
+                    "f64".to_string(),
+                    Rc::new(TypeDef::make_number("f64", 8, true, true)),
+                ),
+                ("bool".to_string(), Rc::new(TypeDef::Native("bool"))),
+                ("char".to_string(), Rc::new(TypeDef::Native("char"))),
+                ("str".to_string(), Rc::new(TypeDef::Native("str"))),
+                ("void".to_string(), Rc::new(TypeDef::Native("void"))),
             ]),
             fields: HashMap::new(),
         }
     }
 
-    pub fn headers(mut self, declarations: &'a [Decl]) -> Header<'a> {
+    pub fn headers(mut self, declarations: &[Decl]) -> Header {
         for declaration in declarations {
             self.visit_decl(declaration);
         }
         self
     }
 
-    pub fn analysed(
-        self,
-    ) -> (
-        HashMap<&'a str, Rc<TypeDef<'a>>>,
-        HashMap<&'a str, Rc<TypeDef<'a>>>,
-    ) {
+    pub fn analysed(self) -> (TypeNames, TypeNames) {
         (self.types, self.fields)
     }
 
     fn make_function_type(
         &self,
-        return_type: &'a Option<Token>,
-        params: &'a [(Token, Token)],
-    ) -> Rc<TypeDef<'a>> {
+        return_type: &TypeCell,
+        params: &[(Identifier, TypeCell)],
+    ) -> Rc<TypeDef> {
         let mut parameters = Vec::new();
         for (_, param_type) in params {
-            parameters.push(self.get_type(param_type));
+            parameters.push(param_type.borrow().clone());
         }
-
-        let return_type = if let Some(type_name) = return_type {
-            self.get_type(type_name)
-        } else {
-            self.types
-                .get("void")
-                .expect("expected void type exists")
-                .clone()
-        };
 
         Rc::new(TypeDef::Function {
             parameters,
-            return_type,
+            return_type: return_type.borrow().clone(),
         })
-    }
-
-    fn get_type(&self, name: &'a Token) -> Rc<TypeDef<'a>> {
-        let ref_name = name.identifier();
-        if let Some(ref_type) = self.types.get(ref_name) {
-            ref_type.clone()
-        } else {
-            Rc::new(TypeDef::Lazy(ref_name))
-        }
     }
 }
 
-impl<'a> DeclVisitor<'a, ()> for Header<'a> {
+impl<'a> DeclVisitor<'a, ()> for Header {
     fn visit_import(&mut self, _: &'a Token) {
         // TODO: open import file and add imported fields and types here
     }
 
     fn visit_struct(
         &mut self,
-        name: &'a Token,
-        fields: &'a [(Token, Token)],
+        name: &'a Identifier,
+        fields: &'a [(Identifier, TypeCell)],
         methods: &'a [Rc<Decl>],
     ) {
-        let struct_name = name.identifier();
+        let struct_name = name.get_name().to_string();
 
         let mut members = HashMap::new();
         for (field_name, field_type) in fields {
-            members.insert(field_name.identifier(), self.get_type(field_type));
+            members.insert(
+                field_name.get_name().to_string(),
+                field_type.borrow().clone(),
+            );
         }
         for decl in methods {
             if let Decl::Function {
@@ -266,10 +118,10 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
                 return_type,
                 params,
                 ..
-            } = &**decl
+            } = decl.as_ref()
             {
                 members.insert(
-                    name.identifier(),
+                    name.get_name().to_string(),
                     self.make_function_type(return_type, params),
                 );
             }
@@ -278,7 +130,7 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
         self.types.insert(
             struct_name,
             Rc::new(TypeDef::Struct {
-                name: struct_name,
+                name: name.clone(),
                 members,
             }),
         );
@@ -286,19 +138,20 @@ impl<'a> DeclVisitor<'a, ()> for Header<'a> {
 
     fn visit_function(
         &mut self,
-        name: &'a Token,
-        return_type: &'a Option<Token>,
-        params: &'a [(Token, Token)],
+        name: &'a Identifier,
+        return_type: &'a TypeCell,
+        params: &'a [(Identifier, TypeCell)],
         _: &[Stmt],
+        _: bool,
     ) {
         self.fields.insert(
-            name.identifier(),
+            name.get_name().to_string(),
             self.make_function_type(return_type, params),
         );
     }
 
-    fn visit_const(&mut self, name: &'a Token, var_type: &'a Token, _: &Expr) {
+    fn visit_const(&mut self, name: &'a Identifier, var_type: &'a TypeCell, _: &Expr) {
         self.fields
-            .insert(name.identifier(), self.get_type(var_type));
+            .insert(name.get_name().to_string(), var_type.borrow().clone());
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, fs, path::PathBuf, rc::Rc};
 
 use crate::{
     ast::{Decl, DeclVisitor, Expr, Identifier, Stmt},
-    lexer::Token,
+    lexer::Lexer,
+    parser::Parser,
     typing::{TypeCell, TypeDef, TypeNames},
 };
 
@@ -93,8 +94,27 @@ impl Header {
 }
 
 impl<'a> DeclVisitor<'a, ()> for Header {
-    fn visit_import(&mut self, _: &'a Token) {
-        // TODO: open import file and add imported fields and types here
+    fn visit_import(&mut self, path: &[Identifier]) {
+        let mut module_name = "";
+        let filename = {
+            let mut filename = PathBuf::new();
+            for name in path {
+                filename.push(name.get_name());
+                module_name = name.get_name();
+            }
+            filename.set_extension("tau");
+            filename
+        };
+        let content = fs::read_to_string(filename).expect("Expected to open file");
+        let lexer = Lexer::new(content.chars());
+        let parser = Parser::new(lexer.scan());
+        let ast = parser.parse();
+        let header = Header::new().headers(&ast);
+        let (types, fields) = header.analysed();
+        self.fields.insert(
+            module_name.to_string(),
+            Rc::new(TypeDef::Module { types, fields }),
+        );
     }
 
     fn visit_struct(

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -194,12 +194,10 @@ impl Lexer<'_> {
                             self.advance();
                         }
                         return self.scan_token();
+                    } else if self.matchc('=') {
+                        TokenType::SetDiv
                     } else {
-                        if self.matchc('=') {
-                            TokenType::SetDiv
-                        } else {
-                            TokenType::Div
-                        }
+                        TokenType::Div
                     }
                 }
                 '&' => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,21 +1,26 @@
+use crate::ast::Identifier;
 use std::collections::VecDeque;
 use std::iter::Peekable;
 use std::str::Chars;
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct Source {
+    line: u32,
+    column: u32,
+}
+
+#[derive(Debug, PartialEq)]
 #[allow(dead_code)]
 pub struct Token {
     token_type: TokenType,
-    line: u32,
-    column: u32,
+    source: Source,
 }
 
 impl Token {
     pub fn new(token_type: TokenType, line: u32, column: u32) -> Token {
         Token {
             token_type,
-            line,
-            column,
+            source: Source { line, column },
         }
     }
 
@@ -28,6 +33,26 @@ impl Token {
             TokenType::Identifier(name) => name,
             TokenType::VSelf => "self",
             _ => panic!("expected identifier"),
+        }
+    }
+}
+
+impl From<Token> for Identifier {
+    fn from(token: Token) -> Self {
+        match token.get_type() {
+            TokenType::Identifier(name) => Identifier::new(name.to_string(), token.source),
+            TokenType::VSelf => Identifier::new("self".to_string(), token.source),
+            _ => panic!("token '{:?}' is not a identifier", token),
+        }
+    }
+}
+
+impl From<&Token> for Identifier {
+    fn from(token: &Token) -> Self {
+        if let TokenType::Identifier(name) = token.get_type() {
+            Identifier::new(name.to_string(), token.source.clone())
+        } else {
+            panic!()
         }
     }
 }
@@ -85,13 +110,14 @@ pub enum TokenType {
     Match,
     Let,
     Const,
+    Extern,
     Return,
     Break,
     VSelf,
 
     // Literal
     Bool(bool),
-    Number(i32),
+    Number(f64),
     String(String),
     Identifier(String),
 
@@ -126,12 +152,11 @@ impl Lexer<'_> {
         while !self.is_at_end() {
             self.scan_token();
         }
-        self.add_token(TokenType::Eof);
         self.tokens
     }
 
     fn scan_token(&mut self) {
-        if let Some(c) = self.advance() {
+        let token_type = if let Some(c) = self.advance() {
             match c {
                 '(' => TokenType::ParenLeft,
                 ')' => TokenType::ParenRight,
@@ -257,6 +282,7 @@ impl Lexer<'_> {
             "struct" => TokenType::Struct,
             "fn" => TokenType::Function,
             "const" => TokenType::Const,
+            "extern" => TokenType::Extern,
             "let" => TokenType::Let,
             "if" => TokenType::If,
             "else" => TokenType::Else,
@@ -273,9 +299,17 @@ impl Lexer<'_> {
 
     fn number(&mut self, c: char) -> TokenType {
         let mut text = String::from(c);
-        while !self.is_at_end() && Lexer::is_digit(*self.peek().expect("unexpected eof")) {
-            if let Some(c) = self.advance() {
-                text.push(c);
+        let mut is_float = false;
+        while !self.is_at_end() {
+            let next = *self.peek().expect("unexpected eof");
+            if Lexer::is_digit(next) {
+                text.push(self.advance().expect("unexpected eof, expected digit"));
+            } else if next == '.' {
+                assert!(!is_float);
+                is_float = true;
+                text.push(self.advance().expect("unexpected eof, expected dot"));
+            } else {
+                break;
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,26 @@
 use crate::{
-    ast::StmtVisitor, header::Header, lexer::Lexer, parser::Parser, resolution::Resolution,
+    ast::StmtVisitor,
+    compiler::{
+        Compiler,
+        cpp::{CppCodeGenerator, CppHeaderGenerator},
+        replace_extension,
+    },
+    header::Header,
+    lexer::Lexer,
+    parser::Parser,
+    resolution::Resolution,
 };
-use std::{env, fs, io};
+use std::{collections::HashMap, env, fs, io};
 
 mod ast;
+mod compiler;
 mod header;
 mod lexer;
 mod parser;
 mod resolution;
+mod typing;
 
-fn main() {
+fn main() -> Result<(), io::Error> {
     let args: Vec<String> = env::args().collect();
     match args.len() {
         1 => {
@@ -21,7 +32,8 @@ fn main() {
                 if tokens.len() > 1 {
                     let mut parser = Parser::new(tokens);
                     let ast = parser.stmt();
-                    let mut resolution = Resolution::new(Header::new());
+                    let (types, fields) = (HashMap::new(), HashMap::new());
+                    let mut resolution = Resolution::new(&types, fields);
                     resolution.visit_stmt(&ast);
                     println!("{:#?}", resolution);
                     buffer.clear();
@@ -29,17 +41,29 @@ fn main() {
                     break;
                 }
             }
+            Ok(())
         }
         2 => {
-            let content = fs::read_to_string(args.get(1).unwrap()).expect("Expected to open file");
+            let filename = args.get(1).unwrap();
+            let content = fs::read_to_string(filename).expect("Expected to open file");
             let lexer = Lexer::new(content.chars());
             let parser = Parser::new(lexer.scan());
             let ast = parser.parse();
             let header = Header::new().headers(&ast);
-            let resolution = Resolution::new(header);
-            println!("{:#?}", resolution.resolve(&ast).analysed());
+            let (types, fields) = header.analysed();
+            let resolution = Resolution::new(&types, fields).resolve(&ast);
+            let _ = resolution.analysed();
+            let compiler = Compiler::new(&ast);
+            let header_output = replace_extension(filename, "hpp");
+            compiler.compile(CppHeaderGenerator, &header_output)?;
+            let code_output = replace_extension(filename, "cpp");
+            compiler.compile(CppCodeGenerator::new(), &code_output)?;
+            Ok(())
         }
-        _ => println!("usage: {:?} [file]", args.first().unwrap()),
+        _ => {
+            println!("usage: {:?} [file]", args.first().unwrap());
+            Err(io::Error::new(io::ErrorKind::Other, "false usage"))
+        }
     }
 }
 
@@ -48,7 +72,7 @@ mod tests {
     use crate::{
         ast::StmtVisitor, header::Header, lexer::Lexer, parser::Parser, resolution::Resolution,
     };
-    use std::fs;
+    use std::{collections::HashMap, fs};
 
     #[test]
     fn lexer() {
@@ -89,7 +113,8 @@ mod tests {
         let lexer = Lexer::new(content.chars());
         let mut parser = Parser::new(lexer.scan());
         let ast = parser.stmt();
-        let mut resolution = Resolution::new(Header::new());
+        let (types, fields) = (HashMap::new(), HashMap::new());
+        let mut resolution = Resolution::new(&types, fields);
         println!("{:#?}", resolution.visit_stmt(&ast));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_return)]
 use crate::{
     ast::StmtVisitor,
     compiler::{
@@ -62,7 +63,7 @@ fn main() -> Result<(), io::Error> {
         }
         _ => {
             println!("usage: {:?} [file]", args.first().unwrap());
-            Err(io::Error::new(io::ErrorKind::Other, "false usage"))
+            Err(io::Error::other("false usage"))
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,9 @@
 use crate::{
-    ast::{Decl, Expr, Stmt},
+    ast::{Decl, Expr, Identifier, Stmt},
     lexer::{Token, TokenType},
+    typing::TypeDef,
 };
-use std::collections::VecDeque;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 // Pratt parser inspired after the following block post:
 // https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
@@ -33,7 +33,8 @@ impl Parser {
         let token = self.advance();
         match token.get_type() {
             TokenType::Import => self.decl_import(),
-            TokenType::Function => self.decl_function(),
+            TokenType::Extern => self.decl_extern(),
+            TokenType::Function => self.decl_function(false),
             TokenType::Struct => self.decl_struct(),
             TokenType::Const => self.decl_const(),
             _ => todo!("unimplemented decl: {:?}", token),
@@ -46,7 +47,15 @@ impl Parser {
         Decl::Import(next)
     }
 
-    fn decl_function(&mut self) -> Decl {
+    fn decl_extern(&mut self) -> Decl {
+        let token = self.advance();
+        match token.get_type() {
+            TokenType::Function => self.decl_function(true),
+            _ => todo!("unimplemented decl: {:?}", token),
+        }
+    }
+
+    fn decl_function(&mut self, is_extern: bool) -> Decl {
         let name = self.advance();
         assert!(name.get_type().is_identifer(), "{:?}", name);
 
@@ -60,27 +69,30 @@ impl Parser {
         }
         self.consume(&TokenType::ParenRight);
 
-        let return_type = if *self.peek().get_type() != TokenType::BraceLeft {
+        let return_type = if *self.peek().get_type() == TokenType::Colon {
             self.consume(&TokenType::Colon);
             let type_name = self.advance();
             assert!(type_name.get_type().is_identifer());
-            Some(type_name)
+            TypeDef::Lazy(type_name.identifier().to_string())
         } else {
-            None
+            TypeDef::Lazy("void".to_string())
         };
 
-        self.consume(&TokenType::BraceLeft);
         let mut body = Vec::new();
-        while *self.peek().get_type() != TokenType::BraceRight {
-            body.push(self.stmt());
+        if !is_extern {
+            self.consume(&TokenType::BraceLeft);
+            while *self.peek().get_type() != TokenType::BraceRight {
+                body.push(self.stmt());
+            }
+            self.consume(&TokenType::BraceRight);
         }
-        self.consume(&TokenType::BraceRight);
 
         Decl::Function {
-            name,
-            return_type,
+            name: Identifier::from(name),
+            return_type: RefCell::new(Rc::new(return_type)),
             params,
             body,
+            is_extern,
         }
     }
 
@@ -100,12 +112,12 @@ impl Parser {
         let mut methods = Vec::new();
         while *self.peek().get_type() != TokenType::BraceRight {
             self.consume(&TokenType::Function);
-            methods.push(Rc::new(self.decl_function()));
+            methods.push(Rc::new(self.decl_function(false)));
         }
 
         self.consume(&TokenType::BraceRight);
         Decl::Struct {
-            name,
+            name: Identifier::from(name),
             fields,
             methods,
         }
@@ -122,13 +134,16 @@ impl Parser {
         }
     }
 
-    fn decl_type_def(&mut self) -> (Token, Token) {
+    fn decl_type_def(&mut self) -> (Identifier, RefCell<Rc<TypeDef>>) {
         let name = self.advance();
         assert!(name.get_type().is_identifer(), "{:?}", name);
         self.consume(&TokenType::Colon);
         let type_name = self.advance();
         assert!(type_name.get_type().is_identifer(), "{:?}", type_name);
-        (name, type_name)
+        (
+            Identifier::from(name),
+            RefCell::new(Rc::new(TypeDef::Lazy(type_name.identifier().to_string()))),
+        )
     }
 
     pub(crate) fn stmt(&mut self) -> Stmt {
@@ -166,15 +181,15 @@ impl Parser {
             self.consume(&TokenType::Colon);
             let type_name = self.advance();
             assert!(type_name.get_type().is_identifer());
-            Some(type_name)
+            TypeDef::Lazy(type_name.identifier().to_string())
         } else {
-            None
+            TypeDef::Unknown
         };
         self.consume(&TokenType::Set);
         let initializer = self.expr();
         Stmt::Let {
-            name,
-            var_type,
+            name: Identifier::from(name),
+            var_type: RefCell::new(Rc::new(var_type)),
             initializer,
         }
     }
@@ -213,16 +228,26 @@ impl Parser {
                             self.expr_create_array(next, Some(expr))
                         } else {
                             Expr::Index {
-                                object: Rc::new(Expr::Variable(next)),
+                                object: Rc::new(Expr::Variable {
+                                    name: Identifier::from(next),
+                                    variable_type: RefCell::new(Rc::new(TypeDef::Unknown)),
+                                }),
                                 index: expr,
+                                lookup: RefCell::new(Rc::new(TypeDef::Unknown)),
                             }
                         }
                     }
                 } else {
-                    Expr::Variable(next)
+                    Expr::Variable {
+                        name: Identifier::from(next),
+                        variable_type: RefCell::new(Rc::new(TypeDef::Unknown)),
+                    }
                 }
             }
-            TokenType::VSelf => Expr::Variable(next),
+            TokenType::VSelf => Expr::Variable {
+                name: Identifier::from(next),
+                variable_type: RefCell::new(Rc::new(TypeDef::Unknown)),
+            },
             TokenType::Add | TokenType::Sub | TokenType::Not => self.expr_unary(next),
             TokenType::ParenLeft => self.expr_grouping(),
             TokenType::If => self.expr_if(),
@@ -275,6 +300,7 @@ impl Parser {
         Expr::Index {
             object: Rc::new(lhs),
             index: Rc::new(rhs),
+            lookup: RefCell::new(Rc::new(TypeDef::Unknown)),
         }
     }
 
@@ -306,10 +332,15 @@ impl Parser {
         let next = self.advance();
         if *next.get_type() == TokenType::Dot {
             let rhs = self.advance();
-            assert!(rhs.get_type().is_identifer());
+            assert!(
+                rhs.get_type().is_identifer(),
+                "failed to read token: {:?}",
+                &rhs
+            );
             Expr::Get {
                 left: Rc::new(lhs),
                 right: rhs,
+                lookup: RefCell::new(Rc::new(TypeDef::Unknown)),
             }
         } else {
             let rhs = self.expr_bp(bp);
@@ -333,7 +364,7 @@ impl Parser {
         self.consume(&TokenType::BraceRight);
 
         Expr::CreateArray {
-            array_type,
+            array_type: RefCell::new(Rc::new(TypeDef::Lazy(array_type.identifier().to_string()))),
             array_size,
             fields,
         }
@@ -347,7 +378,7 @@ impl Parser {
             assert!(name.get_type().is_identifer(), "{:?}", name);
             self.consume(&TokenType::Set);
             let expr = Rc::new(self.expr());
-            let field = (name, expr);
+            let field = (Identifier::from(name), expr);
             fields.push(field);
             if *self.peek().get_type() != TokenType::BraceRight {
                 self.consume(&TokenType::Comma);
@@ -355,7 +386,7 @@ impl Parser {
         }
         self.consume(&TokenType::BraceRight);
         Expr::CreateStruct {
-            struct_name,
+            struct_type: RefCell::new(Rc::new(TypeDef::Lazy(struct_name.identifier().to_string()))),
             fields,
         }
     }
@@ -375,6 +406,7 @@ impl Parser {
             condition,
             if_branch,
             else_branch,
+            expression_type: RefCell::new(Rc::new(TypeDef::Unknown)),
         }
     }
 
@@ -415,7 +447,13 @@ impl Parser {
 
     fn consume(&mut self, expected: &TokenType) -> Token {
         let next = self.advance();
-        assert_eq!(next.get_type(), expected, "{:?}", next);
+        assert_eq!(
+            next.get_type(),
+            expected,
+            "expected {:?}, but got {:?}",
+            expected,
+            next
+        );
         next
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,9 +42,16 @@ impl Parser {
     }
 
     fn decl_import(&mut self) -> Decl {
-        let next = self.advance();
-        assert!(next.get_type().is_identifer());
-        Decl::Import(next)
+        let mut path = Vec::new();
+        loop {
+            path.push(Identifier::from(self.advance()));
+            if *self.peek().get_type() == TokenType::Dot {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Decl::Import(path)
     }
 
     fn decl_extern(&mut self) -> Decl {
@@ -339,7 +346,7 @@ impl Parser {
             );
             Expr::Get {
                 left: Rc::new(lhs),
-                right: rhs,
+                right: Identifier::from(rhs),
                 lookup: RefCell::new(Rc::new(TypeDef::Unknown)),
             }
         } else {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -9,11 +9,8 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 #[derive(Debug)]
 pub struct Resolution<'a> {
     types: &'a TypeNames,
-    // Current scopes is the list of all scopes we visited once. The map contains all
-    // variable names mapped to its type.
-    scopes: Vec<Rc<RefCell<TypeNames>>>,
     // Current scope is the list of the scope we are currently in and all scopes above it.
-    current_scope: Vec<Rc<RefCell<TypeNames>>>,
+    scopes: Vec<Rc<RefCell<TypeNames>>>,
     return_type: Option<Rc<TypeDef>>,
 }
 
@@ -21,8 +18,7 @@ impl<'a> Resolution<'a> {
     pub fn new(types: &'a TypeNames, fields: TypeNames) -> Resolution<'a> {
         Resolution {
             types,
-            scopes: Vec::new(),
-            current_scope: vec![Rc::new(RefCell::new(fields))],
+            scopes: vec![Rc::new(RefCell::new(fields))],
             return_type: None,
         }
     }
@@ -44,7 +40,7 @@ impl<'a> Resolution<'a> {
 
     fn declare_variable(&mut self, var_name: &str, var_type: Rc<TypeDef>) {
         assert!(
-            (*self.current_scope.last_mut().expect("expected scope"))
+            (*self.scopes.last_mut().expect("expected scope"))
                 .borrow_mut()
                 .insert(var_name.to_string(), var_type)
                 .is_none()
@@ -52,13 +48,13 @@ impl<'a> Resolution<'a> {
     }
 
     fn lookup_variable(&mut self, var_name: &str) -> Rc<TypeDef> {
-        if let Some(scope) = self.current_scope.last() {
+        if let Some(scope) = self.scopes.last() {
             if let Some(v) = scope.borrow().get(var_name) {
                 v.clone()
             } else {
-                let origin = self.current_scope.pop().expect("expected scope");
+                let origin = self.scopes.pop().expect("expected scope");
                 let var_type = self.lookup_variable(var_name);
-                self.current_scope.push(origin);
+                self.scopes.push(origin);
                 var_type
             }
         } else {
@@ -89,11 +85,21 @@ impl<'a> Resolution<'a> {
         }
     }
 
-    fn get_member(&self, struct_type: Rc<TypeDef>, member_name: &'a str) -> Rc<TypeDef> {
-        if let TypeDef::Struct { name: _, members } = struct_type.as_ref() {
+    fn get_member(&self, lookup: Rc<TypeDef>, member_name: &'a str) -> Rc<TypeDef> {
+        if let TypeDef::Struct { name: _, members } = lookup.as_ref() {
             let ref_type: Rc<TypeDef> = members
                 .get(member_name)
                 .expect("expected struct contains field")
+                .clone();
+            if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
+                self.get_type(&lazy_name)
+            } else {
+                ref_type
+            }
+        } else if let TypeDef::Module { types: _, fields } = lookup.as_ref() {
+            let ref_type = fields
+                .get(member_name)
+                .expect("expected modue contains field")
                 .clone();
             if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
                 self.get_type(&lazy_name)
@@ -107,12 +113,11 @@ impl<'a> Resolution<'a> {
 
     fn begin_scope(&mut self) {
         let ref_counter = Rc::new(RefCell::new(HashMap::new()));
-        self.current_scope.push(ref_counter.clone());
         self.scopes.push(ref_counter);
     }
 
     fn end_scope(&mut self) {
-        self.current_scope.pop().expect("expect end scope");
+        self.scopes.pop().expect("expect end scope");
     }
 }
 
@@ -189,14 +194,13 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef>> for Resolution<'a> {
     fn visit_get(
         &mut self,
         left: &'a Rc<Expr>,
-        right: &'a Token,
+        right: &'a Identifier,
         lookup: &'a TypeCell,
     ) -> Rc<TypeDef> {
         let l = self.visit_expr(left);
-        let r = right.identifier();
-        let ref_type = self.get_member(l, r);
-        *lookup.borrow_mut() = ref_type.clone();
-        ref_type
+        *lookup.borrow_mut() = l.clone();
+        let r = right.get_name();
+        self.get_member(l, r)
     }
 
     fn visit_index(
@@ -401,7 +405,7 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef>>> for Resolution<'a> {
 }
 
 impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
-    fn visit_import(&mut self, _: &Token) {}
+    fn visit_import(&mut self, _: &[Identifier]) {}
 
     fn visit_struct(
         &mut self,
@@ -415,7 +419,7 @@ impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
             .get(name.get_name())
             .expect("expected to find own struct name when trying to reference self")
             .clone();
-        (*self.current_scope.last_mut().expect("expected scope"))
+        (*self.scopes.last_mut().expect("expected scope"))
             .borrow_mut()
             .insert("self".to_string(), struct_type);
         for (_, member_type) in members {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -66,20 +66,19 @@ impl<'a> Resolution<'a> {
         let ref_type: Rc<TypeDef> = self
             .types
             .get(name)
-            .expect(
-                format!(
+            .unwrap_or_else(|| {
+                panic!(
                     "expected type name does not exist '{}' in {:#?}",
                     name, self
                 )
-                .as_str(),
-            )
+            })
             .clone();
         self.get_ref_type(ref_type)
     }
 
     fn get_ref_type(&self, ref_type: Rc<TypeDef>) -> Rc<TypeDef> {
         if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
-            self.get_type(&lazy_name)
+            self.get_type(lazy_name)
         } else {
             ref_type
         }
@@ -92,7 +91,7 @@ impl<'a> Resolution<'a> {
                 .expect("expected struct contains field")
                 .clone();
             if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
-                self.get_type(&lazy_name)
+                self.get_type(lazy_name)
             } else {
                 ref_type
             }
@@ -102,7 +101,7 @@ impl<'a> Resolution<'a> {
                 .expect("expected modue contains field")
                 .clone();
             if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
-                self.get_type(&lazy_name)
+                self.get_type(lazy_name)
             } else {
                 ref_type
             }
@@ -231,7 +230,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef>> for Resolution<'a> {
             for (argument, para_type) in arguments.iter().zip(parameters) {
                 let arg_type = self.visit_expr(argument);
                 assert!(
-                    arg_type.is_castable_to(&*self.get_ref_type(para_type.clone())),
+                    arg_type.is_castable_to(&self.get_ref_type(para_type.clone())),
                     "argument type '{}' supplied to function does not match parameter type '{}'",
                     arg_type,
                     para_type
@@ -273,7 +272,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef>> for Resolution<'a> {
             let field_type = self.visit_expr(field_expr);
             assert!(
                 field_type
-                    .is_castable_to(&*self.get_member(ref_type.clone(), field_name.get_name()))
+                    .is_castable_to(&self.get_member(ref_type.clone(), field_name.get_name()))
             );
         }
         *struct_type.borrow_mut() = ref_type.clone();

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,33 +1,28 @@
-use std::collections::HashMap;
-use std::collections::VecDeque;
-use std::rc::Rc;
-
-use crate::ast::DeclVisitor;
-use crate::ast::ExprVisitor;
-use crate::ast::StmtVisitor;
-use crate::ast::{Decl, Expr, Stmt};
-use crate::header::Header;
-use crate::header::TypeDef;
-use crate::lexer::{Token, TokenType};
+use crate::{
+    ast::{Decl, DeclVisitor, Expr, ExprVisitor, Identifier, Stmt, StmtVisitor},
+    lexer::{Token, TokenType},
+    typing::TypeCell,
+    typing::{TypeDef, TypeNames},
+};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 #[derive(Debug)]
 pub struct Resolution<'a> {
-    types: HashMap<&'a str, Rc<TypeDef<'a>>>,
-    // Current scopes is the deque of all scopes we visited once. The map contains all
+    types: &'a TypeNames,
+    // Current scopes is the list of all scopes we visited once. The map contains all
     // variable names mapped to its type.
-    all_scopes: VecDeque<HashMap<&'a str, Rc<TypeDef<'a>>>>,
-    // Current scopes is the deque of the scope we are currently in and all scopes above it.
-    current_scopes: VecDeque<HashMap<&'a str, Rc<TypeDef<'a>>>>,
-    return_type: Option<Rc<TypeDef<'a>>>,
+    scopes: Vec<Rc<RefCell<TypeNames>>>,
+    // Current scope is the list of the scope we are currently in and all scopes above it.
+    current_scope: Vec<Rc<RefCell<TypeNames>>>,
+    return_type: Option<Rc<TypeDef>>,
 }
 
 impl<'a> Resolution<'a> {
-    pub fn new(header: Header<'a>) -> Resolution<'a> {
-        let (types, fields) = header.analysed();
+    pub fn new(types: &'a TypeNames, fields: TypeNames) -> Resolution<'a> {
         Resolution {
             types,
-            all_scopes: VecDeque::new(),
-            current_scopes: VecDeque::from([fields]),
+            scopes: Vec::new(),
+            current_scope: vec![Rc::new(RefCell::new(fields))],
             return_type: None,
         }
     }
@@ -43,42 +38,36 @@ impl<'a> Resolution<'a> {
         self
     }
 
-    pub fn analysed(
-        self,
-    ) -> (
-        HashMap<&'a str, Rc<TypeDef<'a>>>,
-        VecDeque<HashMap<&'a str, Rc<TypeDef<'a>>>>,
-    ) {
-        (self.types, self.all_scopes)
+    pub fn analysed(self) -> Vec<Rc<RefCell<TypeNames>>> {
+        self.scopes
     }
 
-    fn declare_variable(&mut self, var_name: &'a Token, var_type: Rc<TypeDef<'a>>) {
+    fn declare_variable(&mut self, var_name: &str, var_type: Rc<TypeDef>) {
         assert!(
-            self.current_scopes
-                .back_mut()
-                .expect("expected scope")
-                .insert(var_name.identifier(), var_type)
+            (*self.current_scope.last_mut().expect("expected scope"))
+                .borrow_mut()
+                .insert(var_name.to_string(), var_type)
                 .is_none()
         );
     }
 
-    fn lookup_variable(&mut self, var_name: &Token) -> Rc<TypeDef<'a>> {
-        match self.current_scopes.back() {
-            Some(scope) => match scope.get(var_name.identifier()) {
-                Some(v) => v.clone(),
-                _ => {
-                    let origin = self.current_scopes.pop_back().expect("expected scope");
-                    let var_type = self.lookup_variable(var_name);
-                    self.current_scopes.push_back(origin);
-                    var_type
-                }
-            },
-            _ => panic!("could not find variable '{}'", var_name.identifier()),
+    fn lookup_variable(&mut self, var_name: &str) -> Rc<TypeDef> {
+        if let Some(scope) = self.current_scope.last() {
+            if let Some(v) = scope.borrow().get(var_name) {
+                v.clone()
+            } else {
+                let origin = self.current_scope.pop().expect("expected scope");
+                let var_type = self.lookup_variable(var_name);
+                self.current_scope.push(origin);
+                var_type
+            }
+        } else {
+            panic!("could not find variable '{}'", var_name);
         }
     }
 
-    fn get_type(&self, name: &str) -> Rc<TypeDef<'a>> {
-        let ref_type: Rc<TypeDef<'a>> = self
+    fn get_type(&self, name: &str) -> Rc<TypeDef> {
+        let ref_type: Rc<TypeDef> = self
             .types
             .get(name)
             .expect(
@@ -92,22 +81,22 @@ impl<'a> Resolution<'a> {
         self.get_ref_type(ref_type)
     }
 
-    fn get_ref_type(&self, ref_type: Rc<TypeDef<'a>>) -> Rc<TypeDef<'a>> {
-        if let TypeDef::Lazy(lazy_name) = *ref_type {
-            self.get_type(lazy_name)
+    fn get_ref_type(&self, ref_type: Rc<TypeDef>) -> Rc<TypeDef> {
+        if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
+            self.get_type(&lazy_name)
         } else {
             ref_type
         }
     }
 
-    fn get_member(&self, struct_type: Rc<TypeDef<'a>>, member_name: &'a str) -> Rc<TypeDef<'a>> {
-        if let TypeDef::Struct { name: _, members } = &*struct_type {
-            let ref_type: Rc<TypeDef<'a>> = members
+    fn get_member(&self, struct_type: Rc<TypeDef>, member_name: &'a str) -> Rc<TypeDef> {
+        if let TypeDef::Struct { name: _, members } = struct_type.as_ref() {
+            let ref_type: Rc<TypeDef> = members
                 .get(member_name)
                 .expect("expected struct contains field")
                 .clone();
-            if let TypeDef::Lazy(lazy_name) = *ref_type {
-                self.get_type(lazy_name)
+            if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
+                self.get_type(&lazy_name)
             } else {
                 ref_type
             }
@@ -117,17 +106,18 @@ impl<'a> Resolution<'a> {
     }
 
     fn begin_scope(&mut self) {
-        self.current_scopes.push_back(HashMap::new());
+        let ref_counter = Rc::new(RefCell::new(HashMap::new()));
+        self.current_scope.push(ref_counter.clone());
+        self.scopes.push(ref_counter);
     }
 
     fn end_scope(&mut self) {
-        let old_scope = self.current_scopes.pop_back().expect("expect end scope");
-        self.all_scopes.push_front(old_scope);
+        self.current_scope.pop().expect("expect end scope");
     }
 }
 
-impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
-    fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> Rc<TypeDef<'a>> {
+impl<'a> ExprVisitor<'a, Rc<TypeDef>> for Resolution<'a> {
+    fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> Rc<TypeDef> {
         let r = self.visit_expr(right);
         match operator.get_type() {
             TokenType::Not => {
@@ -147,7 +137,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
         left: &'a Rc<Expr>,
         operator: &Token,
         right: &'a Rc<Expr>,
-    ) -> Rc<TypeDef<'a>> {
+    ) -> Rc<TypeDef> {
         let l = self.visit_expr(left);
         let r = self.visit_expr(right);
         match operator.get_type() {
@@ -196,24 +186,38 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
         }
     }
 
-    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Token) -> Rc<TypeDef<'a>> {
+    fn visit_get(
+        &mut self,
+        left: &'a Rc<Expr>,
+        right: &'a Token,
+        lookup: &'a TypeCell,
+    ) -> Rc<TypeDef> {
         let l = self.visit_expr(left);
         let r = right.identifier();
-        self.get_member(l, r)
+        let ref_type = self.get_member(l, r);
+        *lookup.borrow_mut() = ref_type.clone();
+        ref_type
     }
 
-    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>) -> Rc<TypeDef<'a>> {
+    fn visit_index(
+        &mut self,
+        object: &'a Rc<Expr>,
+        index: &'a Rc<Expr>,
+        looup: &'a TypeCell,
+    ) -> Rc<TypeDef> {
         let l = self.visit_expr(object);
         if let TypeDef::Array(array_type) = &*l {
             let r = self.visit_expr(index);
             assert!(r.is_integer());
-            self.get_ref_type(array_type.clone())
+            let ref_type = self.get_ref_type(array_type.clone());
+            *looup.borrow_mut() = ref_type.clone();
+            ref_type
         } else {
             panic!("expected to index array")
         }
     }
 
-    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> Rc<TypeDef<'a>> {
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> Rc<TypeDef> {
         let callee_type = self.visit_expr(callee);
         if let TypeDef::Function {
             parameters,
@@ -237,15 +241,16 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
 
     fn visit_create_array(
         &mut self,
-        array_type: &'a Token,
+        array_type: &'a TypeCell,
         array_size: &'a Option<Rc<Expr>>,
         fields: &'a [Rc<Expr>],
-    ) -> Rc<TypeDef<'a>> {
-        let name = array_type.identifier();
+    ) -> Rc<TypeDef> {
         if let Some(size_expr) = array_size {
             assert!(self.visit_expr(size_expr).is_integer());
         }
-        let ref_type = self.get_type(name);
+        let ref_type = self.get_ref_type(array_type.borrow().clone());
+        *array_type.borrow_mut() = ref_type.clone();
+
         for field in fields {
             assert!(self.visit_expr(field).is_castable_to(&ref_type))
         }
@@ -255,23 +260,19 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
 
     fn visit_create_struct(
         &mut self,
-        struct_name: &'a Token,
-        fields: &'a [(Token, Rc<Expr>)],
-    ) -> Rc<TypeDef<'a>> {
-        let name = struct_name.identifier();
-        let ref_type = if let Some(ref_type) = self.types.get(name) {
-            ref_type.clone()
-        } else {
-            panic!("use of undeclared struct type");
-        };
+        struct_type: &'a TypeCell,
+        fields: &'a [(Identifier, Rc<Expr>)],
+    ) -> Rc<TypeDef> {
+        let ref_type = self.get_ref_type(struct_type.borrow().clone());
 
         for (field_name, field_expr) in fields {
             let field_type = self.visit_expr(field_expr);
-            assert_eq!(
-                self.get_member(ref_type.clone(), field_name.identifier()),
+            assert!(
                 field_type
+                    .is_castable_to(&*self.get_member(ref_type.clone(), field_name.get_name()))
             );
         }
+        *struct_type.borrow_mut() = ref_type.clone();
         ref_type
     }
 
@@ -280,12 +281,14 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
         condition: &'a Rc<Expr>,
         if_branch: &'a Rc<Stmt>,
         else_branch: &'a Option<Rc<Stmt>>,
-    ) -> Rc<TypeDef<'a>> {
+        expression_type: &'a TypeCell,
+    ) -> Rc<TypeDef> {
         self.visit_expr(condition);
         if let Some(if_type) = self.visit_stmt(if_branch) {
             if let Some(branch) = else_branch {
                 if let Some(else_type) = self.visit_stmt(branch) {
                     assert_eq!(if_type, else_type);
+                    *expression_type.borrow_mut() = if_type.clone();
                     return if_type;
                 } else {
                     panic!("return type of if branch does not match else branch");
@@ -305,7 +308,7 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
             .clone()
     }
 
-    fn visit_literal(&mut self, value: &Token) -> Rc<TypeDef<'a>> {
+    fn visit_literal(&mut self, value: &Token) -> Rc<TypeDef> {
         self.types
             .get(match value.get_type() {
                 TokenType::Number(_) => "i32",
@@ -317,13 +320,15 @@ impl<'a> ExprVisitor<'a, Rc<TypeDef<'a>>> for Resolution<'a> {
             .clone()
     }
 
-    fn visit_variable(&mut self, name: &Token) -> Rc<TypeDef<'a>> {
-        self.lookup_variable(name)
+    fn visit_variable(&mut self, name: &Identifier, variable_type: &'a TypeCell) -> Rc<TypeDef> {
+        let real_type = self.lookup_variable(name.get_name());
+        *variable_type.borrow_mut() = real_type.clone();
+        real_type
     }
 }
 
-impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
-    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Option<Rc<TypeDef<'a>>> {
+impl<'a> StmtVisitor<'a, Option<Rc<TypeDef>>> for Resolution<'a> {
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Option<Rc<TypeDef>> {
         self.begin_scope();
         for stmt in statements {
             assert!(self.return_type.is_none(), "function has already returned");
@@ -335,34 +340,34 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
 
     fn visit_let(
         &mut self,
-        name: &'a Token,
-        var_type: &'a Option<Token>,
+        name: &'a Identifier,
+        var_type: &'a TypeCell,
         initializer: &'a Expr,
-    ) -> Option<Rc<TypeDef<'a>>> {
-        let real_type = self.visit_expr(initializer);
-        if let Some(expected_type) = &*var_type {
-            let ref_type = self.get_type(expected_type.identifier());
+    ) -> Option<Rc<TypeDef>> {
+        let mut real_type = self.visit_expr(initializer);
+        if let TypeDef::Lazy(expected_type) = var_type.borrow().as_ref() {
+            let ref_type = self.get_type(expected_type);
             if real_type.is_castable_to(&ref_type) {
-                self.declare_variable(name, ref_type);
+                real_type = ref_type;
             } else {
                 panic!();
             }
-        } else {
-            self.declare_variable(name, real_type);
         }
+        self.declare_variable(name.get_name(), real_type.clone());
+        *var_type.borrow_mut() = real_type;
         None
     }
 
-    fn visit_return(&mut self, value: &'a Expr) -> Option<Rc<TypeDef<'a>>> {
+    fn visit_return(&mut self, value: &'a Expr) -> Option<Rc<TypeDef>> {
         self.return_type = Some(self.visit_expr(value));
         None
     }
 
-    fn visit_break(&mut self) -> Option<Rc<TypeDef<'a>>> {
+    fn visit_break(&mut self) -> Option<Rc<TypeDef>> {
         None
     }
 
-    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Option<Rc<TypeDef<'a>>> {
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Option<Rc<TypeDef>> {
         self.begin_scope();
         assert!(
             self.visit_expr(condition).is_bool(),
@@ -379,7 +384,7 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
         condition: &'a Expr,
         increment: &'a Expr,
         body: &'a Rc<Stmt>,
-    ) -> Option<Rc<TypeDef<'a>>> {
+    ) -> Option<Rc<TypeDef>> {
         self.begin_scope();
         self.visit_stmt(initializer);
         assert!(self.visit_expr(condition).is_bool());
@@ -390,7 +395,7 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
         None
     }
 
-    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Option<Rc<TypeDef<'a>>> {
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Option<Rc<TypeDef>> {
         Some(self.visit_expr(expr))
     }
 }
@@ -398,17 +403,25 @@ impl<'a> StmtVisitor<'a, Option<Rc<TypeDef<'a>>>> for Resolution<'a> {
 impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
     fn visit_import(&mut self, _: &Token) {}
 
-    fn visit_struct(&mut self, name: &'a Token, _: &'a [(Token, Token)], methods: &'a [Rc<Decl>]) {
+    fn visit_struct(
+        &mut self,
+        name: &'a Identifier,
+        members: &'a [(Identifier, TypeCell)],
+        methods: &'a [Rc<Decl>],
+    ) {
         self.begin_scope();
         let struct_type = self
             .types
-            .get(name.identifier())
+            .get(name.get_name())
             .expect("expected to find own struct name when trying to reference self")
             .clone();
-        self.current_scopes
-            .back_mut()
-            .expect("expected scope")
-            .insert("self", struct_type);
+        (*self.current_scope.last_mut().expect("expected scope"))
+            .borrow_mut()
+            .insert("self".to_string(), struct_type);
+        for (_, member_type) in members {
+            let ref_type = self.get_ref_type(member_type.borrow().clone());
+            *member_type.borrow_mut() = ref_type;
+        }
         for method in methods {
             self.visit_decl(method);
         }
@@ -417,48 +430,47 @@ impl<'a> DeclVisitor<'a, ()> for Resolution<'a> {
 
     fn visit_function(
         &mut self,
-        _: &'a Token,
-        return_type: &'a Option<Token>,
-        params: &'a [(Token, Token)],
+        _: &'a Identifier,
+        return_type: &'a TypeCell,
+        params: &'a [(Identifier, TypeCell)],
         body: &'a [Stmt],
+        is_extern: bool,
     ) {
         assert!(self.return_type.is_none());
+        let ref_type = self.get_ref_type(return_type.borrow().clone());
+        *return_type.borrow_mut() = ref_type.clone();
         self.begin_scope();
         for (param_name, param_type) in params {
-            self.declare_variable(param_name, self.get_type(param_type.identifier()));
+            let ref_type = self.get_ref_type(param_type.borrow().clone());
+            self.declare_variable(param_name.get_name(), ref_type.clone());
+            *param_type.borrow_mut() = ref_type;
+        }
+        if is_extern {
+            // This function is defined outside of tau, there is no body that we can typecheck.
+            self.end_scope();
+            return;
         }
         for stmt in body {
             self.visit_stmt(stmt);
         }
-        let expected = if let Some(type_name) = return_type {
-            type_name.identifier()
-        } else {
-            "void"
-        };
         let real = self.get_ref_type(
             self.return_type
                 .clone()
                 .unwrap_or_else(|| self.get_type("void")),
         );
         assert!(
-            real.is_castable_to(&self.get_type(expected)),
-            "could not cast {} to {}",
-            real,
-            expected
+            real.is_castable_to(ref_type.as_ref()),
+            "could not cast {}",
+            real
         );
+
         self.return_type = None;
         self.end_scope();
     }
 
-    fn visit_const(
-        &mut self,
-        _: &'a crate::lexer::Token,
-        var_type: &'a crate::lexer::Token,
-        initializer: &'a crate::ast::Expr,
-    ) {
-        assert_eq!(
-            self.get_type(var_type.identifier()),
-            self.visit_expr(initializer)
-        );
+    fn visit_const(&mut self, _: &'a Identifier, var_type: &'a TypeCell, initializer: &'a Expr) {
+        let ref_type = self.get_ref_type(var_type.borrow().clone());
+        assert_eq!(ref_type.clone(), self.visit_expr(initializer));
+        *var_type.borrow_mut() = ref_type;
     }
 }

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -171,7 +171,7 @@ impl Display for TypeDef {
                 signed: _,
             }
             | Self::Native(name) => formatter.write_str(name),
-            Self::Lazy(name) => formatter.write_str(&name),
+            Self::Lazy(name) => formatter.write_str(name),
             Self::Unknown => formatter.write_str("Unknown"),
         }
     }

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -1,0 +1,174 @@
+use crate::ast::*;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fmt::{Display, Formatter, Result},
+    rc::Rc,
+};
+
+#[derive(Debug, PartialEq)]
+pub enum TypeDef {
+    Struct {
+        name: Identifier,
+        members: HashMap<String, Rc<TypeDef>>,
+    },
+    Function {
+        parameters: Vec<Rc<TypeDef>>,
+        return_type: Rc<TypeDef>,
+    },
+    Array(Rc<TypeDef>),
+    Number {
+        name: &'static str,
+        size: u8,
+        float: bool,
+        signed: bool,
+    },
+    Native(&'static str),
+    Lazy(String),
+    Unknown,
+}
+
+impl TypeDef {
+    pub fn make_number(name: &'static str, size: u8, float: bool, signed: bool) -> TypeDef {
+        Self::Number {
+            name,
+            size,
+            float,
+            signed,
+        }
+    }
+
+    pub fn is_castable_to(&self, to: &Self) -> bool {
+        match self {
+            Self::Number {
+                name: _,
+                size,
+                float,
+                signed: _,
+            } => {
+                let (this_size, this_float) = (size, float);
+                if let Self::Number {
+                    name: _,
+                    size,
+                    float,
+                    signed: _,
+                } = to
+                {
+                    if *this_float {
+                        return *float && this_size <= size;
+                    } else {
+                        return this_size <= size;
+                    }
+                } else {
+                    return false;
+                }
+            }
+            Self::Function {
+                parameters,
+                return_type,
+            } => {
+                let (this_para, this_return) = (parameters, return_type);
+                if let Self::Function {
+                    parameters,
+                    return_type,
+                } = to
+                {
+                    for (par_from, par_to) in this_para.iter().zip(parameters) {
+                        if !par_from.is_castable_to(par_to) {
+                            return false;
+                        }
+                    }
+                    return this_return.is_castable_to(return_type);
+                } else {
+                    return false;
+                }
+            }
+            Self::Struct { name, members: _ } => {
+                let this_name = name;
+                if let TypeDef::Struct { name, members: _ } = to {
+                    return this_name == name;
+                } else {
+                    return false;
+                }
+            }
+            Self::Native(this_name) => {
+                if let Self::Native(name) = to {
+                    return this_name == name;
+                } else {
+                    return false;
+                }
+            }
+            _ => {
+                panic!(
+                    "tried to typecheck the lazy type '{}' that was not dereferenced yet",
+                    self
+                )
+            }
+        }
+    }
+
+    pub fn is_integer(&self) -> bool {
+        if let TypeDef::Number {
+            name: _,
+            size: _,
+            float,
+            signed: _,
+        } = *self
+        {
+            return !float;
+        }
+        false
+    }
+
+    pub fn is_number(&self) -> bool {
+        if let TypeDef::Number {
+            name,
+            size: _,
+            float: _,
+            signed: _,
+        } = *self
+        {
+            return matches!(
+                name,
+                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64"
+            );
+        }
+        false
+    }
+
+    pub fn is_bool(&self) -> bool {
+        if let TypeDef::Native(name) = *self {
+            name == "bool"
+        } else {
+            false
+        }
+    }
+}
+
+impl Display for TypeDef {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Struct { name, members: _ } => formatter.write_str(name.get_name()),
+            Self::Function {
+                parameters,
+                return_type,
+            } => write!(formatter, "{:?} -> {}", parameters, return_type),
+            Self::Array(array_type) => {
+                write!(formatter, "{:?}[]", array_type)
+            }
+            Self::Number {
+                name,
+                size: _,
+                float: _,
+                signed: _,
+            }
+            | Self::Native(name) => formatter.write_str(name),
+            Self::Lazy(name) => formatter.write_str(&name),
+            Self::Unknown => formatter.write_str("Unknown"),
+        }
+    }
+}
+
+pub type TypeNames = HashMap<String, Rc<TypeDef>>;
+
+pub type TypeCell = RefCell<Rc<TypeDef>>;

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -8,6 +8,10 @@ use std::{
 
 #[derive(Debug, PartialEq)]
 pub enum TypeDef {
+    Module {
+        types: TypeNames,
+        fields: TypeNames,
+    },
     Struct {
         name: Identifier,
         members: HashMap<String, Rc<TypeDef>>,
@@ -16,7 +20,6 @@ pub enum TypeDef {
         parameters: Vec<Rc<TypeDef>>,
         return_type: Rc<TypeDef>,
     },
-    Array(Rc<TypeDef>),
     Number {
         name: &'static str,
         size: u8,
@@ -24,6 +27,7 @@ pub enum TypeDef {
         signed: bool,
     },
     Native(&'static str),
+    Array(Rc<TypeDef>),
     Lazy(String),
     Unknown,
 }
@@ -148,6 +152,10 @@ impl TypeDef {
 impl Display for TypeDef {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
         match self {
+            Self::Module {
+                types: _,
+                fields: _,
+            } => formatter.write_str("<module>"),
             Self::Struct { name, members: _ } => formatter.write_str(name.get_name()),
             Self::Function {
                 parameters,


### PR DESCRIPTION
**Features**
- Structs
- If, Else, For, While, Break
- Let
- Extern C functions
- Garbage collecter (Uses C++)
- Ternary expressions / expressive If's
- Imports

**Todo**
- No lambdas
- No generic types
- No automatic creation of the extern C code
- Only limited handling of identifiers that are not Tau keywords but C/C++ keywords
- Issues with Strings / Pointers

**Usage**

This compiler allows to compile Tau to C++. If you want to compile a `example.tau` program that contains external C code, you need to first write the C code and then run the following commands:

```sh
cargo run example.tau
gcc -c example-extern.c -o example-extern.o
g++ -c example.cpp -o example.o
g++ example-extern.o example.o -o example
```
