### PR TITLE
Add perf for profiling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[rust]
+# Get more debug info for profiling https://nnethercote.github.io/perf-book/profiling.html
+debuginfo-level = 1
+
+[build]
+# Force frame pointers and symbol demangling for profiling
+rustflags = ["-C", "force-frame-pointers=yes", "-C", "symbol-mangling-version=v0"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
+# Rust
 result
+
 .direnv/
+
+# Nix
 target
 .pre-commit-config.yaml
+
+# Profiling
+gecko_profile.json
+perf.data
+perf.data.old

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,17 @@ We follow the [rust style guide](https://doc.rust-lang.org/beta/style-guide/).
 
 Please ensure your code adheres to these conventions before submitting a pull request.
 
+## Profiling
+
+If you want to profile Tau, we recommend using `perf`. You can run
+
+```sh
+perf-record --call-graph dwarf -- ./target/debug/tau ./your/code/test.tau
+perf-report script report gecko
+```
+
+for recording and uploading the performance for Tau to the Firefox profiler.
+
 ---
 
 Thank you for helping improve Tau!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ rust-version = "1.85"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[profile.release]
+debug = "line-tables-only"

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
         devDependencies = with pkgs; [
           bacon
           sccache
+          perf
         ];
       in
         with pkgs; {
@@ -55,6 +56,8 @@
             buildInputs = bi ++ devDependencies;
             shellHook = ''
               ${config.pre-commit.installationScript}
+              alias perf-record="perf record --call-graph dwarf -- ./target/debug/tau examples/vec2.tau"
+              alias perf-report="perf script report gecko"
             '';
           };
           packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,6 @@
             buildInputs = bi ++ devDependencies;
             shellHook = ''
               ${config.pre-commit.installationScript}
-              alias perf-record="perf record --call-graph dwarf -- ./target/debug/tau examples/vec2.tau"
-              alias perf-report="perf script report gecko"
             '';
           };
           packages = rec {


### PR DESCRIPTION
**Changes made**
This pr adds perf, wich allows profiling and performance measuring of the generated binary. You can see an online example here: https://share.firefox.dev/49CNUpk. You can invoke it by running `perf-record` and show the results with `perf-report`.

**Checklist**

- Build on platform:
  - [ ] Windows 10/11
  - [x] Linux (NixOS)
  - [ ] macOS
- [x] Tested all changes (run `cargo test`)
- [x] Formatted all files (run `cargo fmt`)
- [x] Fits [CONTRIBUTING.md](https://github.com/tau-lang/tau/blob/master/CONTRIBUTING.md)
- [x] Fits [CODE_OF_CONDUCT.md](https://github.com/tau-lang/tau/blob/main/CODE_OF_CONDUCT.md)
