### PR TITLE
Add new tokens to lexer

### DIFF
--- a/examples/arrays.tau
+++ b/examples/arrays.tau
@@ -1,14 +1,15 @@
-extern fn println(data: str)
+extern proc println(data: str)
 
-extern fn i32_to_str(input: i32): str
+extern proc i32_to_str(input: i32) -> str
 
-fn main(): void {
+func plus1(i: i32) -> i32 = i + 1
+
+proc main() {
     let a = i32[2 * 8] { 0, 0 }
     let i = 0
     while (i < 16) {
         a[i] = i
-        i += 1
+        i = plus1(i)
     }
     println(i32_to_str(a[15]))
-    return 0
 }

--- a/examples/arrays.tau
+++ b/examples/arrays.tau
@@ -1,10 +1,10 @@
-extern proc println(data: str)
+extern fn println(data: str)
 
-extern proc i32_to_str(input: i32) -> str
+extern fn i32_to_str(input: i32) -> str
 
-func plus1(i: i32) -> i32 = i + 1
+fn plus1(i: i32) -> i32 = i + 1
 
-proc main() {
+io fn main() {
     let a = i32[2 * 8] { 0, 0 }
     let i = 0
     while (i < 16) {

--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -1,24 +1,24 @@
-extern fn sqrt(v: f64): f64
+extern func sqrt(v: f64) -> f64
 
-extern fn println(v: str)
+extern proc println(v: str)
 
 struct vec2 {
     x: f64,
     y: f64
 
-    fn add(x: f64, y: f64): vec2 {
+    proc add(x: f64, y: f64) -> vec2 {
         self.x += x
         self.y += y
         return self
     }
 
-    fn sub(x: f64, y: f64): vec2 {
+    proc sub(x: f64, y: f64) -> vec2 {
         self.x -= x
         self.y -= y
         return self
     }
 
-    fn norm(): vec2 {
+    proc norm() -> vec2 {
         let mag = self.magnitude()
         if (mag != 0) {
             self.x /= mag
@@ -27,24 +27,18 @@ struct vec2 {
         return self
     }
 
-    fn copy(): vec2 {
-        return vec2_new(self.x, self.y)
-    }
+    func copy() -> vec2 = vec2_new(self.x, self.y)
 
-    fn magnitude(): f64 {
-        return sqrt(self.x * self.x + self.y * self.y)
-    }
+    func magnitude() -> f64 =
+        sqrt(self.x * self.x + self.y * self.y)
 }
 
 const ZERO: vec2 = vec2 { x=0, y=0 }
 
-fn vec2_new(x: f64, y: f64): vec2 {
-    let created = vec2 { x=x, y=y }
-    return created
-}
+func vec2_new(x: f64, y: f64) -> vec2 =
+    vec2 { x=x, y=y }
 
-fn main(): i32 {
+proc main() {
     let _a: vec2 = vec2_new(3, 4).add(4, -2)
     println("Hello, World!")
-    return 0
 }

--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -1,24 +1,24 @@
-extern func sqrt(v: f64) -> f64
+extern fn sqrt(v: f64) -> f64
 
-extern proc println(v: str)
+extern fn println(v: str)
 
 struct vec2 {
     x: f64,
     y: f64
 
-    proc add(x: f64, y: f64) -> vec2 {
+    fn add(x: f64, y: f64) -> vec2 {
         self.x += x
         self.y += y
         return self
     }
 
-    proc sub(x: f64, y: f64) -> vec2 {
+    fn sub(x: f64, y: f64) -> vec2 {
         self.x -= x
         self.y -= y
         return self
     }
 
-    proc norm() -> vec2 {
+    fn norm() -> vec2 {
         let mag = self.magnitude()
         if (mag != 0) {
             self.x /= mag
@@ -27,18 +27,18 @@ struct vec2 {
         return self
     }
 
-    func copy() -> vec2 = vec2_new(self.x, self.y)
+    fn copy() -> vec2 = vec2_new(self.x, self.y)
 
-    func magnitude() -> f64 =
+    fn magnitude() -> f64 =
         sqrt(self.x * self.x + self.y * self.y)
 }
 
 const ZERO: vec2 = vec2 { x=0, y=0 }
 
-func vec2_new(x: f64, y: f64) -> vec2 =
+fn vec2_new(x: f64, y: f64) -> vec2 =
     vec2 { x=x, y=y }
 
-proc main() {
+io fn main() {
     let _a: vec2 = vec2_new(3, 4).add(4, -2)
     println("Hello, World!")
 }

--- a/examples/vec2.tau
+++ b/examples/vec2.tau
@@ -27,6 +27,20 @@ struct vec2 {
         return self
     }
 
+    fn diff(other: vec2) -> vec2 =
+        let
+            dx = self.x - other.x
+            dy = self.y - other.y
+        in
+            vec2 { x=dx, y=dy }
+
+    fn midpoint(other: vec2) -> vec2 =
+        let
+            mx = (self.x + other.x) * 0.5
+            my = (self.y + other.y) * 0.5
+        in
+            vec2 { x=mx, y=my }
+
     fn copy() -> vec2 = vec2_new(self.x, self.y)
 
     fn magnitude() -> f64 =

--- a/src/ast/declaration.rs
+++ b/src/ast/declaration.rs
@@ -12,7 +12,7 @@ pub enum Decl {
         fields: Vec<(Identifier, TypeCell)>,
         methods: Vec<Rc<Decl>>,
     },
-    Procedure {
+    Function {
         name: Identifier,
         return_type: TypeCell,
         params: Vec<(Identifier, TypeCell)>,
@@ -37,7 +37,7 @@ pub trait DeclVisitor<'a> {
                 fields,
                 methods,
             } => self.visit_struct(name, fields, methods),
-            Decl::Procedure {
+            Decl::Function {
                 name,
                 return_type,
                 params,

--- a/src/ast/declaration.rs
+++ b/src/ast/declaration.rs
@@ -26,8 +26,10 @@ pub enum Decl {
     },
 }
 
-pub trait DeclVisitor<'a, T> {
-    fn visit_decl(&mut self, decl: &'a Decl) -> T {
+pub trait DeclVisitor<'a> {
+    type Output;
+
+    fn visit_decl(&mut self, decl: &'a Decl) -> Self::Output {
         match decl {
             Decl::Import(name) => self.visit_import(name),
             Decl::Struct {
@@ -50,14 +52,14 @@ pub trait DeclVisitor<'a, T> {
         }
     }
 
-    fn visit_import(&mut self, path: &'a [Identifier]) -> T;
+    fn visit_import(&mut self, path: &'a [Identifier]) -> Self::Output;
 
     fn visit_struct(
         &mut self,
         name: &'a Identifier,
         fields: &'a [(Identifier, TypeCell)],
         methods: &'a [Rc<Decl>],
-    ) -> T;
+    ) -> Self::Output;
 
     fn visit_function(
         &mut self,
@@ -66,12 +68,12 @@ pub trait DeclVisitor<'a, T> {
         params: &'a [(Identifier, TypeCell)],
         body: &'a [Stmt],
         is_extern: bool,
-    ) -> T;
+    ) -> Self::Output;
 
     fn visit_const(
         &mut self,
         name: &'a Identifier,
         var_type: &'a TypeCell,
         initializer: &'a Expr,
-    ) -> T;
+    ) -> Self::Output;
 }

--- a/src/ast/declaration.rs
+++ b/src/ast/declaration.rs
@@ -12,7 +12,7 @@ pub enum Decl {
         fields: Vec<(Identifier, TypeCell)>,
         methods: Vec<Rc<Decl>>,
     },
-    Function {
+    Procedure {
         name: Identifier,
         return_type: TypeCell,
         params: Vec<(Identifier, TypeCell)>,
@@ -37,13 +37,13 @@ pub trait DeclVisitor<'a> {
                 fields,
                 methods,
             } => self.visit_struct(name, fields, methods),
-            Decl::Function {
+            Decl::Procedure {
                 name,
                 return_type,
                 params,
                 body,
                 is_extern,
-            } => self.visit_function(name, return_type, params, body, *is_extern),
+            } => self.visit_procedure(name, return_type, params, body, *is_extern),
             Decl::Const {
                 name,
                 var_type,
@@ -61,7 +61,7 @@ pub trait DeclVisitor<'a> {
         methods: &'a [Rc<Decl>],
     ) -> Self::Output;
 
-    fn visit_function(
+    fn visit_procedure(
         &mut self,
         name: &'a Identifier,
         return_type: &'a TypeCell,

--- a/src/ast/declaration.rs
+++ b/src/ast/declaration.rs
@@ -18,6 +18,7 @@ pub enum Decl {
         params: Vec<(Identifier, TypeCell)>,
         body: Vec<Stmt>,
         is_extern: bool,
+        is_io: bool,
     },
     Const {
         name: Identifier,
@@ -43,7 +44,8 @@ pub trait DeclVisitor<'a> {
                 params,
                 body,
                 is_extern,
-            } => self.visit_procedure(name, return_type, params, body, *is_extern),
+                is_io,
+            } => self.visit_function(name, return_type, params, body, *is_extern, *is_io),
             Decl::Const {
                 name,
                 var_type,
@@ -61,13 +63,14 @@ pub trait DeclVisitor<'a> {
         methods: &'a [Rc<Decl>],
     ) -> Self::Output;
 
-    fn visit_procedure(
+    fn visit_function(
         &mut self,
         name: &'a Identifier,
         return_type: &'a TypeCell,
         params: &'a [(Identifier, TypeCell)],
         body: &'a [Stmt],
         is_extern: bool,
+        is_io: bool,
     ) -> Self::Output;
 
     fn visit_const(

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -74,8 +74,10 @@ impl Expr {
     }
 }
 
-pub trait ExprVisitor<'a, T> {
-    fn visit_expr(&mut self, expr: &'a Expr) -> T {
+pub trait ExprVisitor<'a> {
+    type Output;
+
+    fn visit_expr(&mut self, expr: &'a Expr) -> Self::Output {
         match expr.kind() {
             ExprKind::Unary { operator, right } => self.visit_unary(operator, right),
             ExprKind::Binary {
@@ -117,29 +119,43 @@ pub trait ExprVisitor<'a, T> {
         }
     }
 
-    fn visit_unary(&mut self, operator: &'a Token, right: &'a Rc<Expr>) -> T;
+    fn visit_unary(&mut self, operator: &'a Token, right: &'a Rc<Expr>) -> Self::Output;
 
-    fn visit_binary(&mut self, left: &'a Rc<Expr>, operator: &'a Token, right: &'a Rc<Expr>) -> T;
+    fn visit_binary(
+        &mut self,
+        left: &'a Rc<Expr>,
+        operator: &'a Token,
+        right: &'a Rc<Expr>,
+    ) -> Self::Output;
 
-    fn visit_get(&mut self, left: &'a Rc<Expr>, right: &'a Identifier, lookup: &'a TypeCell) -> T;
+    fn visit_get(
+        &mut self,
+        left: &'a Rc<Expr>,
+        right: &'a Identifier,
+        lookup: &'a TypeCell,
+    ) -> Self::Output;
 
-    fn visit_index(&mut self, object: &'a Rc<Expr>, index: &'a Rc<Expr>, lookup: &'a TypeCell)
-    -> T;
+    fn visit_index(
+        &mut self,
+        object: &'a Rc<Expr>,
+        index: &'a Rc<Expr>,
+        lookup: &'a TypeCell,
+    ) -> Self::Output;
 
-    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> T;
+    fn visit_call(&mut self, callee: &'a Rc<Expr>, arguments: &'a [Rc<Expr>]) -> Self::Output;
 
     fn visit_create_array(
         &mut self,
         array_type: &'a TypeCell,
         array_size: &'a Option<Rc<Expr>>,
         fields: &'a [Rc<Expr>],
-    ) -> T;
+    ) -> Self::Output;
 
     fn visit_create_struct(
         &mut self,
         struct_name: &'a TypeCell,
         fields: &'a [(Identifier, Rc<Expr>)],
-    ) -> T;
+    ) -> Self::Output;
 
     fn visit_if(
         &mut self,
@@ -147,9 +163,9 @@ pub trait ExprVisitor<'a, T> {
         if_branch: &'a Rc<Stmt>,
         else_branch: &'a Option<Rc<Stmt>>,
         expression_result: &'a TypeCell,
-    ) -> T;
+    ) -> Self::Output;
 
-    fn visit_literal(&mut self, value: &'a Token) -> T;
+    fn visit_literal(&mut self, value: &'a Token) -> Self::Output;
 
-    fn visit_variable(&mut self, name: &'a Identifier, var_type: &'a TypeCell) -> T;
+    fn visit_variable(&mut self, name: &'a Identifier, var_type: &'a TypeCell) -> Self::Output;
 }

--- a/src/ast/identifier.rs
+++ b/src/ast/identifier.rs
@@ -12,10 +12,10 @@ impl Identifier {
         Identifier { name, source }
     }
 
-    pub fn get_source(&self) -> Source {
+    pub fn source(&self) -> Source {
         self.source.clone()
     }
-    pub fn get_name(&self) -> &str {
+    pub fn name(&self) -> &str {
         &self.name
     }
 }

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -24,7 +24,6 @@ impl Stmt {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum StmtType {
     Block {
         statements: Vec<Rc<Stmt>>,
@@ -51,8 +50,10 @@ pub enum StmtType {
     ExprStmt(Expr),
 }
 
-pub trait StmtVisitor<'a, T> {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) -> T {
+pub trait StmtVisitor<'a> {
+    type Output;
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) -> Self::Output {
         match stmt.kind() {
             StmtType::Block { statements } => self.visit_block(statements),
             StmtType::Let {
@@ -73,20 +74,20 @@ pub trait StmtVisitor<'a, T> {
         }
     }
 
-    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> T;
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Self::Output;
 
     fn visit_let(
         &mut self,
         name: &'a Identifier,
         var_type: &'a TypeCell,
         initializer: &'a Expr,
-    ) -> T;
+    ) -> Self::Output;
 
-    fn visit_return(&mut self, value: &'a Expr) -> T;
+    fn visit_return(&mut self, value: &'a Expr) -> Self::Output;
 
-    fn visit_break(&mut self) -> T;
+    fn visit_break(&mut self) -> Self::Output;
 
-    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> T;
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Self::Output;
 
     fn visit_for(
         &mut self,
@@ -94,7 +95,7 @@ pub trait StmtVisitor<'a, T> {
         condition: &'a Expr,
         increment: &'a Expr,
         body: &'a Rc<Stmt>,
-    ) -> T;
+    ) -> Self::Output;
 
-    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> T;
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Self::Output;
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,12 +71,12 @@ impl ArgsBuilder {
         let args: Vec<String> = env::args().collect();
         let mut iter = args.into_iter();
         iter.next()
-            .expect("expect program exists ($0) as firt command line argument");
+            .expect("expect program exists ($0) as first command line argument");
         while let Some(arg) = iter.next() {
             if arg.starts_with('-') {
                 self.parse_option(arg.as_str(), &mut iter)?;
             } else {
-                self.parse_file(iter.next())?;
+                self.parse_file(arg)?;
             }
         }
         Ok(self)
@@ -116,8 +116,11 @@ impl ArgsBuilder {
         }
     }
 
-    fn parse_file(&mut self, next: Option<String>) -> Result<(), String> {
-        if let Some(input) = next {
+    fn parse_file<T>(&mut self, next: T) -> Result<(), String>
+    where
+        T: Into<Option<String>>,
+    {
+        if let Some(input) = next.into() {
             let path_buf = PathBuf::from(input);
             if path_buf.exists() {
                 self.args.input.insert(Rc::new(path_buf));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,15 +42,15 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn get_input(&self) -> &HashSet<Rc<PathBuf>> {
+    pub fn input(&self) -> &HashSet<Rc<PathBuf>> {
         &self.input
     }
 
-    pub fn get_output(&self) -> &Path {
+    pub fn output(&self) -> &Path {
         &self.output
     }
 
-    pub fn get_target(&self) -> &Target {
+    pub fn target(&self) -> &Target {
         &self.target
     }
 }

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -77,7 +77,7 @@ impl From<&TypeCell> for CppSourceCode {
 
 impl From<&Identifier> for CppSourceCode {
     fn from(identifier: &Identifier) -> Self {
-        CppSourceCode(match identifier.get_name() {
+        CppSourceCode(match identifier.name() {
             "self" => "this".to_string(),
             name @ ("alignas" | "alignof" | "and" | "and_eq" | "asm" | "atomic_cancel"
             | "atomic_commit" | "atomic_noexcept" | "auto" | "bitand" | "bitor"
@@ -292,7 +292,7 @@ impl<'a> ExprVisitor<'a> for CppCodeGenerator {
     type Output = CppSourceCode;
 
     fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> CppSourceCode {
-        match operator.get_type() {
+        match operator.token_type() {
             TokenType::Add => format!("+{}", self.visit_expr(right)),
             TokenType::Sub => format!("-{}", self.visit_expr(right)),
             TokenType::Not => format!("!{}", self.visit_expr(right)),
@@ -309,7 +309,7 @@ impl<'a> ExprVisitor<'a> for CppCodeGenerator {
     ) -> CppSourceCode {
         let mut render_op =
             |op: &str| format!("{} {op} {}", self.visit_expr(left), self.visit_expr(right));
-        match operator.get_type() {
+        match operator.token_type() {
             TokenType::Add => render_op("+"),
             TokenType::Sub => render_op("-"),
             TokenType::Mul => render_op("*"),
@@ -340,7 +340,7 @@ impl<'a> ExprVisitor<'a> for CppCodeGenerator {
         lookup: &TypeCell,
     ) -> CppSourceCode {
         let left = self.visit_expr(left);
-        let right = right.get_name();
+        let right = right.name();
         match lookup.borrow().as_ref() {
             TypeDef::Struct {
                 name: _,
@@ -401,7 +401,7 @@ impl<'a> ExprVisitor<'a> for CppCodeGenerator {
     ) -> CppSourceCode {
         let struct_type = struct_type.borrow();
         let struct_type = if let TypeDef::Struct { name, members: _ } = struct_type.as_ref() {
-            name.get_name()
+            name.name()
         } else {
             unreachable!()
         };
@@ -445,7 +445,7 @@ impl<'a> ExprVisitor<'a> for CppCodeGenerator {
     }
 
     fn visit_literal(&mut self, value: &Token) -> CppSourceCode {
-        match value.get_type() {
+        match value.token_type() {
             TokenType::Bool(value) => value.to_string(),
             TokenType::Number(value) => value.to_string(),
             TokenType::String(content) => format!("\"{}\"", content),
@@ -569,7 +569,7 @@ impl<'a> DeclVisitor<'a> for CppCodeGenerator {
         is_extern: bool,
         _: bool,
     ) -> Self::Output {
-        if name.get_name() == "main" {
+        if name.name() == "main" {
             self.main_type = Some(return_type.borrow().clone())
         }
         if is_extern {

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 #[derive(Default, PartialEq, Debug)]
-struct CppSourceCode(String);
+pub struct CppSourceCode(String);
 
 impl Display for CppSourceCode {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), fmt::Error> {
@@ -154,7 +154,8 @@ impl<'a> Generator<'a> for CppHeaderGenerator {
     }
 }
 
-impl DeclVisitor<'_, CppSourceCode> for CppHeaderGenerator {
+impl DeclVisitor<'_> for CppHeaderGenerator {
+    type Output = CppSourceCode;
     fn visit_import(&mut self, path: &[Identifier]) -> CppSourceCode {
         let path = path
             .iter()
@@ -285,7 +286,9 @@ impl<'a> Generator<'a> for CppCodeGenerator {
     }
 }
 
-impl<'a> ExprVisitor<'a, CppSourceCode> for CppCodeGenerator {
+impl<'a> ExprVisitor<'a> for CppCodeGenerator {
+    type Output = CppSourceCode;
+
     fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> CppSourceCode {
         match operator.get_type() {
             TokenType::Add => format!("+{}", self.visit_expr(right)),
@@ -454,8 +457,10 @@ impl<'a> ExprVisitor<'a, CppSourceCode> for CppCodeGenerator {
     }
 }
 
-impl<'a> StmtVisitor<'a, CppSourceCode> for CppCodeGenerator {
-    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> CppSourceCode {
+impl<'a> StmtVisitor<'a> for CppCodeGenerator {
+    type Output = CppSourceCode;
+
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Self::Output {
         let statements = visit_vec(
             statements,
             |stmt| format!("{}", self.visit_stmt(stmt)),
@@ -476,16 +481,16 @@ impl<'a> StmtVisitor<'a, CppSourceCode> for CppCodeGenerator {
         format!("{var_type} {name} = {initializer};").into()
     }
 
-    fn visit_return(&mut self, value: &'a Expr) -> CppSourceCode {
+    fn visit_return(&mut self, value: &'a Expr) -> Self::Output {
         let value = self.visit_expr(value);
         format!("return {value};").into()
     }
 
-    fn visit_break(&mut self) -> CppSourceCode {
+    fn visit_break(&mut self) -> Self::Output {
         "break;".to_string().into()
     }
 
-    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> CppSourceCode {
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Self::Output {
         let condition = self.visit_expr(condition);
         let body = self.visit_stmt(body);
         format!("while ({condition}) {body}").into()
@@ -497,7 +502,7 @@ impl<'a> StmtVisitor<'a, CppSourceCode> for CppCodeGenerator {
         condition: &'a Expr,
         increment: &'a Expr,
         body: &'a Rc<Stmt>,
-    ) -> CppSourceCode {
+    ) -> Self::Output {
         let initializer = self.visit_stmt(initializer);
         let condition = self.visit_expr(condition);
         let increment = self.visit_expr(increment);
@@ -505,14 +510,16 @@ impl<'a> StmtVisitor<'a, CppSourceCode> for CppCodeGenerator {
         format!("for ({initializer}; {condition}; {increment}) {body}").into()
     }
 
-    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> CppSourceCode {
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Self::Output {
         let expr = self.visit_expr(expr);
         format!("{expr};").into()
     }
 }
 
-impl<'a> DeclVisitor<'a, CppSourceCode> for CppCodeGenerator {
-    fn visit_import(&mut self, _: &[Identifier]) -> CppSourceCode {
+impl<'a> DeclVisitor<'a> for CppCodeGenerator {
+    type Output = CppSourceCode;
+
+    fn visit_import(&mut self, _: &[Identifier]) -> Self::Output {
         CppSourceCode::default()
     }
 
@@ -557,7 +564,7 @@ impl<'a> DeclVisitor<'a, CppSourceCode> for CppCodeGenerator {
         params: &[(Identifier, TypeCell)],
         body: &'_ [Stmt],
         is_extern: bool,
-    ) -> CppSourceCode {
+    ) -> Self::Output {
         if name.get_name() == "main" {
             self.main_type = Some(return_type.borrow().clone())
         }
@@ -576,7 +583,7 @@ impl<'a> DeclVisitor<'a, CppSourceCode> for CppCodeGenerator {
         name: &Identifier,
         var_type: &TypeCell,
         initializer: &'_ Expr,
-    ) -> CppSourceCode {
+    ) -> Self::Output {
         let name = CppSourceCode::from(name);
         let var_type = CppSourceCode::from(var_type);
         let initializer = self.visit_expr(initializer);

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -182,6 +182,7 @@ impl DeclVisitor<'_> for CppHeaderGenerator {
                     params,
                     body: _,
                     is_extern: _,
+                    is_io: _,
                 } = decl.as_ref()
                 {
                     format!("  {}", self.visit_method(name, return_type, params))
@@ -194,13 +195,14 @@ impl DeclVisitor<'_> for CppHeaderGenerator {
         format!("class {name} {{\npublic:\n{fields}\n{methods}\n}};").into()
     }
 
-    fn visit_procedure(
+    fn visit_function(
         &mut self,
         name: &Identifier,
         return_type: &TypeCell,
         params: &[(Identifier, TypeCell)],
         _: &[Stmt],
         is_extern: bool,
+        _: bool,
     ) -> CppSourceCode {
         let name = CppSourceCode::from(name);
         let is_extern = if is_extern { "\"C\" " } else { "" };
@@ -539,6 +541,7 @@ impl<'a> DeclVisitor<'a> for CppCodeGenerator {
                     params,
                     body,
                     is_extern,
+                    is_io: _,
                 } = method.as_ref()
                 {
                     format!("{}", self.visit_method(
@@ -557,13 +560,14 @@ impl<'a> DeclVisitor<'a> for CppCodeGenerator {
         )
     }
 
-    fn visit_procedure(
+    fn visit_function(
         &mut self,
         name: &Identifier,
         return_type: &TypeCell,
         params: &[(Identifier, TypeCell)],
         body: &'_ [Stmt],
         is_extern: bool,
+        _: bool,
     ) -> Self::Output {
         if name.get_name() == "main" {
             self.main_type = Some(return_type.borrow().clone())

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -176,7 +176,7 @@ impl DeclVisitor<'_> for CppHeaderGenerator {
         let methods = visit_vec(
             methods,
             |decl| {
-                if let Decl::Function {
+                if let Decl::Procedure {
                     name,
                     return_type,
                     params,
@@ -194,7 +194,7 @@ impl DeclVisitor<'_> for CppHeaderGenerator {
         format!("class {name} {{\npublic:\n{fields}\n{methods}\n}};").into()
     }
 
-    fn visit_function(
+    fn visit_procedure(
         &mut self,
         name: &Identifier,
         return_type: &TypeCell,
@@ -533,7 +533,7 @@ impl<'a> DeclVisitor<'a> for CppCodeGenerator {
         visit_vec(
             methods,
             |method| {
-                if let Decl::Function {
+                if let Decl::Procedure {
                     name,
                     return_type,
                     params,
@@ -557,7 +557,7 @@ impl<'a> DeclVisitor<'a> for CppCodeGenerator {
         )
     }
 
-    fn visit_function(
+    fn visit_procedure(
         &mut self,
         name: &Identifier,
         return_type: &TypeCell,

--- a/src/compiler/cpp.rs
+++ b/src/compiler/cpp.rs
@@ -176,7 +176,7 @@ impl DeclVisitor<'_> for CppHeaderGenerator {
         let methods = visit_vec(
             methods,
             |decl| {
-                if let Decl::Procedure {
+                if let Decl::Function {
                     name,
                     return_type,
                     params,
@@ -533,7 +533,7 @@ impl<'a> DeclVisitor<'a> for CppCodeGenerator {
         visit_vec(
             methods,
             |method| {
-                if let Decl::Procedure {
+                if let Decl::Function {
                     name,
                     return_type,
                     params,

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,10 +7,7 @@ use std::{
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub(crate) fn parser_expected(expected: impl ToString, next: Token) -> Error {
-    Error::new(vec![Diagnostic::new(
-        expected.to_string(),
-        next.get_source(),
-    )])
+    Error::new(vec![Diagnostic::new(expected.to_string(), next.source())])
 }
 
 pub(crate) fn lexer_expected(expected: impl ToString, lexer: &Lexer) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,10 +22,8 @@ pub(crate) fn lexer_expected(expected: impl ToString, lexer: &Lexer) -> Error {
 
 const RESET: &str = "\x1b[0m";
 const BOLD: &str = "\x1b[1m";
-const YELLOW: &str = "\x1b[32m";
 const RED: &str = "\x1b[31m";
 const BLUE: &str = "\x1b[34m";
-const GREEN: &str = "\x1b[93m";
 
 pub struct Error(Vec<Diagnostic>);
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -106,8 +106,8 @@ impl<'a> DeclVisitor<'a> for Header {
         let filename = {
             let mut filename = PathBuf::new();
             for name in path {
-                filename.push(name.get_name());
-                module_name = name.get_name();
+                filename.push(name.name());
+                module_name = name.name();
             }
             filename.set_extension("tau");
             filename
@@ -131,14 +131,11 @@ impl<'a> DeclVisitor<'a> for Header {
         fields: &'a [(Identifier, TypeCell)],
         methods: &'a [Rc<Decl>],
     ) {
-        let struct_name = name.get_name().to_string();
+        let struct_name = name.name().to_string();
 
         let mut members = HashMap::new();
         for (field_name, field_type) in fields {
-            members.insert(
-                field_name.get_name().to_string(),
-                field_type.borrow().clone(),
-            );
+            members.insert(field_name.name().to_string(), field_type.borrow().clone());
         }
         for decl in methods {
             if let Decl::Function {
@@ -149,7 +146,7 @@ impl<'a> DeclVisitor<'a> for Header {
             } = decl.as_ref()
             {
                 members.insert(
-                    name.get_name().to_string(),
+                    name.name().to_string(),
                     self.make_function_type(return_type, params),
                 );
             }
@@ -174,13 +171,13 @@ impl<'a> DeclVisitor<'a> for Header {
         _: bool,
     ) {
         self.fields.insert(
-            name.get_name().to_string(),
+            name.name().to_string(),
             self.make_function_type(return_type, params),
         );
     }
 
     fn visit_const(&mut self, name: &'a Identifier, var_type: &'a TypeCell, _: &Expr) {
         self.fields
-            .insert(name.get_name().to_string(), var_type.borrow().clone());
+            .insert(name.name().to_string(), var_type.borrow().clone());
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -98,7 +98,9 @@ impl Header {
     }
 }
 
-impl<'a> DeclVisitor<'a, ()> for Header {
+impl<'a> DeclVisitor<'a> for Header {
+    type Output = ();
+
     fn visit_import(&mut self, path: &[Identifier]) {
         let mut module_name = "";
         let filename = {

--- a/src/header.rs
+++ b/src/header.rs
@@ -141,7 +141,7 @@ impl<'a> DeclVisitor<'a> for Header {
             );
         }
         for decl in methods {
-            if let Decl::Function {
+            if let Decl::Procedure {
                 name,
                 return_type,
                 params,
@@ -164,7 +164,7 @@ impl<'a> DeclVisitor<'a> for Header {
         );
     }
 
-    fn visit_function(
+    fn visit_procedure(
         &mut self,
         name: &'a Identifier,
         return_type: &'a TypeCell,

--- a/src/header.rs
+++ b/src/header.rs
@@ -141,7 +141,7 @@ impl<'a> DeclVisitor<'a> for Header {
             );
         }
         for decl in methods {
-            if let Decl::Procedure {
+            if let Decl::Function {
                 name,
                 return_type,
                 params,

--- a/src/header.rs
+++ b/src/header.rs
@@ -164,12 +164,13 @@ impl<'a> DeclVisitor<'a> for Header {
         );
     }
 
-    fn visit_procedure(
+    fn visit_function(
         &mut self,
         name: &'a Identifier,
         return_type: &'a TypeCell,
         params: &'a [(Identifier, TypeCell)],
         _: &[Stmt],
+        _: bool,
         _: bool,
     ) {
         self.fields.insert(

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -156,6 +156,7 @@ pub enum TokenType {
     // Keywords
     Import,
     Io,
+    In,
     Function,
     Struct,
     Enum,
@@ -360,6 +361,7 @@ impl Lexer<'_> {
             "import" => TokenType::Import,
             "struct" => TokenType::Struct,
             "io" => TokenType::Io,
+            "in" => TokenType::In,
             "fn" => TokenType::Function,
             "const" => TokenType::Const,
             "extern" => TokenType::Extern,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -128,8 +128,9 @@ pub enum TokenType {
     BracketLeft,  // [
     BracketRight, // ]
     Dot,
-    Comma,
-    Colon,
+    Comma, // ,
+    Colon, // :
+    To,    // ->
 
     // Operators
     Add,
@@ -154,6 +155,7 @@ pub enum TokenType {
 
     // Keywords
     Import,
+    Procedure,
     Function,
     Struct,
     Enum,
@@ -243,6 +245,8 @@ impl Lexer<'_> {
                 '-' => {
                     if self.matchc('=') {
                         TokenType::SetSub
+                    } else if self.matchc('>') {
+                        TokenType::To
                     } else {
                         TokenType::Sub
                     }
@@ -355,7 +359,8 @@ impl Lexer<'_> {
         Ok(match text.as_str() {
             "import" => TokenType::Import,
             "struct" => TokenType::Struct,
-            "fn" => TokenType::Function,
+            "proc" => TokenType::Procedure,
+            "func" => TokenType::Function,
             "const" => TokenType::Const,
             "extern" => TokenType::Extern,
             "let" => TokenType::Let,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -155,7 +155,7 @@ pub enum TokenType {
 
     // Keywords
     Import,
-    Procedure,
+    Io,
     Function,
     Struct,
     Enum,
@@ -359,8 +359,8 @@ impl Lexer<'_> {
         Ok(match text.as_str() {
             "import" => TokenType::Import,
             "struct" => TokenType::Struct,
-            "proc" => TokenType::Procedure,
-            "func" => TokenType::Function,
+            "io" => TokenType::Io,
+            "fn" => TokenType::Function,
             "const" => TokenType::Const,
             "extern" => TokenType::Extern,
             "let" => TokenType::Let,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -75,25 +75,25 @@ impl Token {
         Token { token_type, source }
     }
 
-    pub fn get_type(&self) -> &TokenType {
+    pub fn token_type(&self) -> &TokenType {
         &self.token_type
     }
 
     pub fn identifier(&self) -> &str {
-        match self.get_type() {
+        match self.token_type() {
             TokenType::Identifier(name) => name,
             TokenType::VSelf => "self",
             _ => panic!("expected identifier"),
         }
     }
-    pub fn get_source(&self) -> Source {
+    pub fn source(&self) -> Source {
         self.source.clone()
     }
 }
 
 impl From<Token> for Identifier {
     fn from(token: Token) -> Self {
-        match token.get_type() {
+        match token.token_type() {
             TokenType::Identifier(name) => Identifier::new(name.to_string(), token.source),
             TokenType::VSelf => Identifier::new("self".to_string(), token.source),
             _ => panic!("token '{:?}' is not a identifier", token),
@@ -103,7 +103,7 @@ impl From<Token> for Identifier {
 
 impl From<&Token> for Identifier {
     fn from(token: &Token) -> Self {
-        if let TokenType::Identifier(name) = token.get_type() {
+        if let TokenType::Identifier(name) = token.token_type() {
             Identifier::new(name.to_string(), token.source.clone())
         } else {
             panic!()

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,11 @@ mod typing;
 
 fn main() -> error::Result<()> {
     let args = ArgsBuilder::new().parse().unwrap().build();
-    if args.get_input().is_empty() {
+    if args.input().is_empty() {
         println!("{}", HELP_MESSAGE)
     } else {
         // guaranteed to not be empty
-        for filename in args.get_input() {
+        for filename in args.input() {
             compile_file(filename, &args)?;
         }
     }
@@ -44,12 +44,12 @@ fn compile_file(filename: &Rc<PathBuf>, args: &cli::Args) -> error::Result<()> {
         let header = Header::new().headers(&ast);
         let (types, fields) = header.analysed();
         Resolution::new(&types, fields).resolve(&ast)?;
-        match args.get_target() {
+        match args.target() {
             cli::Target::Cpp => {
                 let compiler = Compiler::new(&ast);
-                let header_output = set_output(filename.as_ref(), args.get_output(), "hpp");
+                let header_output = set_output(filename.as_ref(), args.output(), "hpp");
                 compiler.compile(CppHeaderGenerator, &header_output)?;
-                let code_output = set_output(filename.as_ref(), args.get_output(), "cpp");
+                let code_output = set_output(filename.as_ref(), args.output(), "cpp");
                 compiler.compile(CppCodeGenerator::new(), &code_output)?;
             }
             cli::Target::Cranelift => todo!("hahaha i wish"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,6 +47,7 @@ impl Parser {
             TokenType::Const => self.decl_const(),
             TokenType::Extern => self.decl_extern(),
             TokenType::Function => self.decl_function(false),
+            TokenType::Procedure => self.decl_procedure(false),
             TokenType::Import => self.decl_import(),
             TokenType::Struct => self.decl_struct(),
             t => Err(parser_expected(
@@ -74,11 +75,15 @@ impl Parser {
         let token = self.advance();
         match token.get_type() {
             TokenType::Function => self.decl_function(true),
-            _ => todo!("unimplemented decl: {:?}", token),
+            TokenType::Procedure => self.decl_procedure(true),
+            _ => Err(parser_expected(
+                "can only use extern for procedures and functions",
+                token,
+            )),
         }
     }
 
-    fn decl_function(&mut self, is_extern: bool) -> Result<Decl> {
+    fn decl_procedure(&mut self, is_extern: bool) -> Result<Decl> {
         let name = self.advance();
         if !name.get_type().is_identifer() {
             return Err(parser_expected("expected an function identifier", name));
@@ -94,8 +99,8 @@ impl Parser {
         }
         self.consume(&TokenType::ParenRight)?;
 
-        let return_type = if *self.peek().get_type() == TokenType::Colon {
-            self.consume(&TokenType::Colon)?;
+        let return_type = if *self.peek().get_type() == TokenType::To {
+            self.consume(&TokenType::To)?;
             let type_name = self.advance();
             if !type_name.get_type().is_identifer() {
                 return Err(parser_expected(
@@ -117,7 +122,53 @@ impl Parser {
             self.consume(&TokenType::BraceRight)?;
         }
 
-        Ok(Decl::Function {
+        Ok(Decl::Procedure {
+            name: Identifier::from(name),
+            return_type: RefCell::new(Rc::new(return_type)),
+            params,
+            body,
+            is_extern,
+        })
+    }
+
+    fn decl_function(&mut self, is_extern: bool) -> Result<Decl> {
+        let name = self.advance();
+        if !name.get_type().is_identifer() {
+            return Err(parser_expected("expected an function identifier", name));
+        }
+
+        self.consume(&TokenType::ParenLeft)?;
+        let mut params = Vec::new();
+        while *self.peek().get_type() != TokenType::ParenRight {
+            params.push(self.decl_type_def()?);
+            if *self.peek().get_type() != TokenType::ParenRight {
+                self.consume(&TokenType::Comma)?;
+            }
+        }
+        self.consume(&TokenType::ParenRight)?;
+
+        let return_type = if *self.peek().get_type() == TokenType::To {
+            self.consume(&TokenType::To)?;
+            let type_name = self.advance();
+            if !type_name.get_type().is_identifer() {
+                return Err(parser_expected(
+                    "expected a return type identifier",
+                    type_name,
+                ));
+            }
+            TypeDef::Lazy(type_name.identifier().to_string())
+        } else {
+            TypeDef::Lazy("void".to_string())
+        };
+
+        let mut body = Vec::new();
+        if !is_extern {
+            self.consume(&TokenType::Set)?;
+            let value = self.expr()?;
+            body.push(Stmt::new(value.source(), StmtType::Return { value }));
+        }
+
+        Ok(Decl::Procedure {
             name: Identifier::from(name),
             return_type: RefCell::new(Rc::new(return_type)),
             params,
@@ -156,8 +207,12 @@ impl Parser {
 
         let mut methods = Vec::new();
         while *self.peek().get_type() != TokenType::BraceRight {
-            self.consume(&TokenType::Function)?;
-            methods.push(Rc::new(self.decl_function(false)?));
+            let next = self.advance();
+            methods.push(match next.get_type() {
+                TokenType::Procedure => Ok(Rc::new(self.decl_procedure(false)?)),
+                TokenType::Function => Ok(Rc::new(self.decl_function(false)?)),
+                _ => Err(parser_expected("expected procedure or function", next)),
+            }?);
         }
 
         self.consume(&TokenType::BraceRight)?;
@@ -202,6 +257,7 @@ impl Parser {
                 let current = self.advance();
                 Ok(Stmt::new(current.get_source(), StmtType::Break))
             }
+            TokenType::For => self.stmt_for(),
             TokenType::While => self.stmt_while(),
             _ => {
                 let expr = self.expr()?;
@@ -250,6 +306,27 @@ impl Parser {
                 name: Identifier::from(name),
                 var_type: RefCell::new(Rc::new(var_type)),
                 initializer,
+            },
+        ))
+    }
+
+    fn stmt_for(&mut self) -> Result<Stmt> {
+        let current = self.advance();
+        self.consume(&TokenType::ParenLeft)?;
+        let initializer = Rc::new(self.stmt()?);
+        self.consume(&TokenType::Colon)?;
+        let condition = self.expr()?;
+        self.consume(&TokenType::Colon)?;
+        let increment = self.expr()?;
+        self.consume(&TokenType::ParenRight)?;
+        let body = Rc::new(self.stmt()?);
+        Ok(Stmt::new(
+            Source::union(&current.get_source(), &body.source()),
+            StmtType::For {
+                initializer,
+                condition,
+                increment,
+                body,
             },
         ))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -259,6 +259,22 @@ impl Parser {
         ))
     }
 
+    /// Parses a single let statement. A let statement is of the form:
+    ///
+    /// ```text
+    /// `let` identifier (`:` type)? `=` expr
+    /// ```
+    ///
+    /// Alternativly, currently only available for functions there exists the let/in syntax:
+    ///
+    /// ```text
+    /// `let`
+    ///   (stmt_let)+
+    /// `in`
+    ///   expr
+    /// ```
+    ///
+    /// Not every let statement has its own let token. The keyword may already be consumed by the parser at a previous step. Therefore it may be skipped by setting the skip let arg to true.
     fn stmt_let(&mut self, skip_let: bool) -> Result<Stmt> {
         let (start, name) = if skip_let {
             let next = self.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -45,19 +45,13 @@ impl Parser {
         }
         match token.get_type() {
             TokenType::Const => self.decl_const(),
-            TokenType::Extern => self.decl_extern(),
+            TokenType::Extern => self.decl_modifier(true, false),
+            TokenType::Io => self.decl_modifier(false, true),
             TokenType::Function => self.decl_function(false, false),
-            TokenType::Io => {
-                self.consume(&TokenType::Function)?;
-                self.decl_function(false, false)
-            }
             TokenType::Import => self.decl_import(),
             TokenType::Struct => self.decl_struct(),
             t => Err(parser_expected(
-                format!(
-                    "Found {:?} expected import, function, struct or const",
-                    t.clone()
-                ),
+                format!("Found {:?} expected import, function, struct or const", &t),
                 token,
             )),
         }
@@ -74,12 +68,26 @@ impl Parser {
         })
     }
 
-    fn decl_extern(&mut self) -> Result<Decl> {
+    fn decl_modifier(&mut self, is_extern: bool, is_io: bool) -> Result<Decl> {
         let token = self.advance();
         match token.get_type() {
-            TokenType::Function => self.decl_function(true, true),
+            TokenType::Extern => {
+                if is_extern {
+                    Err(parser_expected("function is already extern", token))
+                } else {
+                    self.decl_modifier(true, is_io)
+                }
+            }
+            TokenType::Io => {
+                if is_io {
+                    Err(parser_expected("function is already io", token))
+                } else {
+                    self.decl_modifier(is_extern, true)
+                }
+            }
+            TokenType::Function => self.decl_function(is_extern, is_io),
             _ => Err(parser_expected(
-                "can only use extern for procedures and functions",
+                "unexpected return type, expected modifier or function",
                 token,
             )),
         }
@@ -136,6 +144,7 @@ impl Parser {
             params,
             body,
             is_extern,
+            is_io,
         })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -123,20 +123,11 @@ impl Parser {
             TypeDef::Lazy("void".to_string())
         };
 
-        let mut body = Vec::new();
-        if !is_extern {
-            if self.peek().get_type() == &TokenType::BraceLeft {
-                self.consume(&TokenType::BraceLeft)?;
-                while *self.peek().get_type() != TokenType::BraceRight {
-                    body.push(self.stmt()?);
-                }
-                self.consume(&TokenType::BraceRight)?;
-            } else {
-                self.consume(&TokenType::Set)?;
-                let value = self.expr()?;
-                body.push(Stmt::new(value.source(), StmtType::Return { value }));
-            }
-        }
+        let body = if is_extern {
+            Vec::new()
+        } else {
+            self.decl_body()?
+        };
 
         Ok(Decl::Function {
             name: Identifier::from(name),
@@ -146,6 +137,29 @@ impl Parser {
             is_extern,
             is_io,
         })
+    }
+
+    fn decl_body(&mut self) -> Result<Vec<Stmt>> {
+        let mut body = Vec::new();
+        if self.peek().get_type() == &TokenType::BraceLeft {
+            self.consume(&TokenType::BraceLeft)?;
+            while *self.peek().get_type() != TokenType::BraceRight {
+                body.push(self.stmt()?);
+            }
+            self.consume(&TokenType::BraceRight)?;
+        } else {
+            self.consume(&TokenType::Set)?;
+            if *self.peek().get_type() == TokenType::Let {
+                self.advance();
+                while *self.peek().get_type() != TokenType::In {
+                    body.push(self.stmt_let(true)?);
+                }
+                self.consume(&TokenType::In)?;
+            }
+            let value = self.expr()?;
+            body.push(Stmt::new(value.source(), StmtType::Return { value }));
+        }
+        Ok(body)
     }
 
     fn decl_import(&mut self) -> Result<Decl> {
@@ -217,7 +231,7 @@ impl Parser {
         let peek = self.peek();
         match peek.get_type() {
             TokenType::BraceLeft => self.stmt_block(),
-            TokenType::Let => self.stmt_let(),
+            TokenType::Let => self.stmt_let(false),
             TokenType::Return => {
                 let current = self.advance();
                 Ok(Stmt::new(
@@ -253,9 +267,13 @@ impl Parser {
         ))
     }
 
-    fn stmt_let(&mut self) -> Result<Stmt> {
-        let current = self.advance();
-        let name = self.advance();
+    fn stmt_let(&mut self, skip_let: bool) -> Result<Stmt> {
+        let (start, name) = if skip_let {
+            let next = self.advance();
+            (next.clone(), next)
+        } else {
+            (self.advance(), self.advance())
+        };
         if !name.get_type().is_identifer() {
             return Err(parser_expected("expected a variable identifier", name));
         }
@@ -275,7 +293,7 @@ impl Parser {
         self.consume(&TokenType::Set)?;
         let initializer = self.expr()?;
         Ok(Stmt::new(
-            Source::union(&current.get_source(), &initializer.source()),
+            Source::union(&start.get_source(), &initializer.source()),
             StmtType::Let {
                 name: Identifier::from(name),
                 var_type: RefCell::new(Rc::new(var_type)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,8 +46,11 @@ impl Parser {
         match token.get_type() {
             TokenType::Const => self.decl_const(),
             TokenType::Extern => self.decl_extern(),
-            TokenType::Function => self.decl_function(false),
-            TokenType::Procedure => self.decl_procedure(false),
+            TokenType::Function => self.decl_function(false, false),
+            TokenType::Io => {
+                self.consume(&TokenType::Function)?;
+                self.decl_function(false, false)
+            }
             TokenType::Import => self.decl_import(),
             TokenType::Struct => self.decl_struct(),
             t => Err(parser_expected(
@@ -74,8 +77,7 @@ impl Parser {
     fn decl_extern(&mut self) -> Result<Decl> {
         let token = self.advance();
         match token.get_type() {
-            TokenType::Function => self.decl_function(true),
-            TokenType::Procedure => self.decl_procedure(true),
+            TokenType::Function => self.decl_function(true, true),
             _ => Err(parser_expected(
                 "can only use extern for procedures and functions",
                 token,
@@ -83,7 +85,7 @@ impl Parser {
         }
     }
 
-    fn decl_procedure(&mut self, is_extern: bool) -> Result<Decl> {
+    fn decl_function(&mut self, is_extern: bool, is_io: bool) -> Result<Decl> {
         let name = self.advance();
         if !name.get_type().is_identifer() {
             return Err(parser_expected("expected an function identifier", name));
@@ -115,60 +117,20 @@ impl Parser {
 
         let mut body = Vec::new();
         if !is_extern {
-            self.consume(&TokenType::BraceLeft)?;
-            while *self.peek().get_type() != TokenType::BraceRight {
-                body.push(self.stmt()?);
-            }
-            self.consume(&TokenType::BraceRight)?;
-        }
-
-        Ok(Decl::Procedure {
-            name: Identifier::from(name),
-            return_type: RefCell::new(Rc::new(return_type)),
-            params,
-            body,
-            is_extern,
-        })
-    }
-
-    fn decl_function(&mut self, is_extern: bool) -> Result<Decl> {
-        let name = self.advance();
-        if !name.get_type().is_identifer() {
-            return Err(parser_expected("expected an function identifier", name));
-        }
-
-        self.consume(&TokenType::ParenLeft)?;
-        let mut params = Vec::new();
-        while *self.peek().get_type() != TokenType::ParenRight {
-            params.push(self.decl_type_def()?);
-            if *self.peek().get_type() != TokenType::ParenRight {
-                self.consume(&TokenType::Comma)?;
+            if self.peek().get_type() == &TokenType::BraceLeft {
+                self.consume(&TokenType::BraceLeft)?;
+                while *self.peek().get_type() != TokenType::BraceRight {
+                    body.push(self.stmt()?);
+                }
+                self.consume(&TokenType::BraceRight)?;
+            } else {
+                self.consume(&TokenType::Set)?;
+                let value = self.expr()?;
+                body.push(Stmt::new(value.source(), StmtType::Return { value }));
             }
         }
-        self.consume(&TokenType::ParenRight)?;
 
-        let return_type = if *self.peek().get_type() == TokenType::To {
-            self.consume(&TokenType::To)?;
-            let type_name = self.advance();
-            if !type_name.get_type().is_identifer() {
-                return Err(parser_expected(
-                    "expected a return type identifier",
-                    type_name,
-                ));
-            }
-            TypeDef::Lazy(type_name.identifier().to_string())
-        } else {
-            TypeDef::Lazy("void".to_string())
-        };
-
-        let mut body = Vec::new();
-        if !is_extern {
-            self.consume(&TokenType::Set)?;
-            let value = self.expr()?;
-            body.push(Stmt::new(value.source(), StmtType::Return { value }));
-        }
-
-        Ok(Decl::Procedure {
+        Ok(Decl::Function {
             name: Identifier::from(name),
             return_type: RefCell::new(Rc::new(return_type)),
             params,
@@ -209,8 +171,11 @@ impl Parser {
         while *self.peek().get_type() != TokenType::BraceRight {
             let next = self.advance();
             methods.push(match next.get_type() {
-                TokenType::Procedure => Ok(Rc::new(self.decl_procedure(false)?)),
-                TokenType::Function => Ok(Rc::new(self.decl_function(false)?)),
+                TokenType::Io => {
+                    self.consume(&TokenType::Io)?;
+                    Ok(Rc::new(self.decl_function(false, true)?))
+                }
+                TokenType::Function => Ok(Rc::new(self.decl_function(false, false)?)),
                 _ => Err(parser_expected("expected procedure or function", next)),
             }?);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,13 +37,13 @@ impl Parser {
 
     pub(crate) fn decl(&mut self) -> Result<Decl> {
         let token = self.advance();
-        if token.get_type() == &TokenType::Eof {
+        if token.token_type() == &TokenType::Eof {
             return Err(parser_expected(
                 "Found end of File but expected a token",
                 token,
             ));
         }
-        match token.get_type() {
+        match token.token_type() {
             TokenType::Const => self.decl_const(),
             TokenType::Extern => self.decl_modifier(true, false),
             TokenType::Io => self.decl_modifier(false, true),
@@ -70,7 +70,7 @@ impl Parser {
 
     fn decl_modifier(&mut self, is_extern: bool, is_io: bool) -> Result<Decl> {
         let token = self.advance();
-        match token.get_type() {
+        match token.token_type() {
             TokenType::Extern => {
                 if is_extern {
                     Err(parser_expected("function is already extern", token))
@@ -95,24 +95,24 @@ impl Parser {
 
     fn decl_function(&mut self, is_extern: bool, is_io: bool) -> Result<Decl> {
         let name = self.advance();
-        if !name.get_type().is_identifer() {
+        if !name.token_type().is_identifer() {
             return Err(parser_expected("expected an function identifier", name));
         }
 
         self.consume(&TokenType::ParenLeft)?;
         let mut params = Vec::new();
-        while *self.peek().get_type() != TokenType::ParenRight {
+        while *self.peek().token_type() != TokenType::ParenRight {
             params.push(self.decl_type_def()?);
-            if *self.peek().get_type() != TokenType::ParenRight {
+            if *self.peek().token_type() != TokenType::ParenRight {
                 self.consume(&TokenType::Comma)?;
             }
         }
         self.consume(&TokenType::ParenRight)?;
 
-        let return_type = if *self.peek().get_type() == TokenType::To {
+        let return_type = if *self.peek().token_type() == TokenType::To {
             self.consume(&TokenType::To)?;
             let type_name = self.advance();
-            if !type_name.get_type().is_identifer() {
+            if !type_name.token_type().is_identifer() {
                 return Err(parser_expected(
                     "expected a return type identifier",
                     type_name,
@@ -141,17 +141,17 @@ impl Parser {
 
     fn decl_body(&mut self) -> Result<Vec<Stmt>> {
         let mut body = Vec::new();
-        if self.peek().get_type() == &TokenType::BraceLeft {
+        if self.peek().token_type() == &TokenType::BraceLeft {
             self.consume(&TokenType::BraceLeft)?;
-            while *self.peek().get_type() != TokenType::BraceRight {
+            while *self.peek().token_type() != TokenType::BraceRight {
                 body.push(self.stmt()?);
             }
             self.consume(&TokenType::BraceRight)?;
         } else {
             self.consume(&TokenType::Set)?;
-            if *self.peek().get_type() == TokenType::Let {
+            if *self.peek().token_type() == TokenType::Let {
                 self.advance();
-                while *self.peek().get_type() != TokenType::In {
+                while *self.peek().token_type() != TokenType::In {
                     body.push(self.stmt_let(true)?);
                 }
                 self.consume(&TokenType::In)?;
@@ -166,7 +166,7 @@ impl Parser {
         let mut path = Vec::new();
         loop {
             path.push(Identifier::from(self.advance()));
-            if *self.peek().get_type() == TokenType::Dot {
+            if *self.peek().token_type() == TokenType::Dot {
                 self.advance();
             } else {
                 break;
@@ -177,30 +177,22 @@ impl Parser {
 
     fn decl_struct(&mut self) -> Result<Decl> {
         let name = self.advance();
-        if !name.get_type().is_identifer() {
+        if !name.token_type().is_identifer() {
             return Err(parser_expected("expected a struct identifier", name));
         };
         self.consume(&TokenType::BraceLeft)?;
 
         let mut fields = Vec::new();
-        while self.peek().get_type().is_identifer() {
+        while self.peek().token_type().is_identifer() {
             fields.push(self.decl_type_def()?);
-            if *self.peek().get_type() == TokenType::Comma {
+            if *self.peek().token_type() == TokenType::Comma {
                 self.consume(&TokenType::Comma)?;
             }
         }
 
         let mut methods = Vec::new();
-        while *self.peek().get_type() != TokenType::BraceRight {
-            let next = self.advance();
-            methods.push(match next.get_type() {
-                TokenType::Io => {
-                    self.consume(&TokenType::Io)?;
-                    Ok(Rc::new(self.decl_function(false, true)?))
-                }
-                TokenType::Function => Ok(Rc::new(self.decl_function(false, false)?)),
-                _ => Err(parser_expected("expected procedure or function", next)),
-            }?);
+        while *self.peek().token_type() != TokenType::BraceRight {
+            methods.push(Rc::new(self.decl_modifier(false, false)?));
         }
 
         self.consume(&TokenType::BraceRight)?;
@@ -213,12 +205,12 @@ impl Parser {
 
     fn decl_type_def(&mut self) -> Result<(Identifier, RefCell<Rc<TypeDef>>)> {
         let name = self.advance();
-        if !name.get_type().is_identifer() {
+        if !name.token_type().is_identifer() {
             return Err(parser_expected("expected a type identifier", name));
         }
         self.consume(&TokenType::Colon)?;
         let type_name = self.advance();
-        if !type_name.get_type().is_identifer() {
+        if !type_name.token_type().is_identifer() {
             return Err(parser_expected("expected a type definition", type_name));
         }
         Ok((
@@ -229,13 +221,13 @@ impl Parser {
 
     pub(crate) fn stmt(&mut self) -> Result<Stmt> {
         let peek = self.peek();
-        match peek.get_type() {
+        match peek.token_type() {
             TokenType::BraceLeft => self.stmt_block(),
             TokenType::Let => self.stmt_let(false),
             TokenType::Return => {
                 let current = self.advance();
                 Ok(Stmt::new(
-                    current.get_source(),
+                    current.source(),
                     StmtType::Return {
                         value: self.expr()?,
                     },
@@ -243,7 +235,7 @@ impl Parser {
             }
             TokenType::Break => {
                 let current = self.advance();
-                Ok(Stmt::new(current.get_source(), StmtType::Break))
+                Ok(Stmt::new(current.source(), StmtType::Break))
             }
             TokenType::For => self.stmt_for(),
             TokenType::While => self.stmt_while(),
@@ -257,12 +249,12 @@ impl Parser {
     fn stmt_block(&mut self) -> Result<Stmt> {
         let current = self.advance();
         let mut statements = Vec::new();
-        while *self.peek().get_type() != TokenType::BraceRight {
+        while *self.peek().token_type() != TokenType::BraceRight {
             statements.push(Rc::new(self.stmt()?));
         }
         let rhs = self.consume(&TokenType::BraceRight)?;
         Ok(Stmt::new(
-            Source::union(&current.get_source(), &rhs.get_source()),
+            Source::union(&current.source(), &rhs.source()),
             StmtType::Block { statements },
         ))
     }
@@ -274,13 +266,13 @@ impl Parser {
         } else {
             (self.advance(), self.advance())
         };
-        if !name.get_type().is_identifer() {
+        if !name.token_type().is_identifer() {
             return Err(parser_expected("expected a variable identifier", name));
         }
-        let var_type = if *self.peek().get_type() != TokenType::Set {
+        let var_type = if *self.peek().token_type() != TokenType::Set {
             self.consume(&TokenType::Colon)?;
             let type_name = self.advance();
-            if !type_name.get_type().is_identifer() {
+            if !type_name.token_type().is_identifer() {
                 return Err(parser_expected(
                     "expected a type identifier for the variable",
                     type_name,
@@ -293,7 +285,7 @@ impl Parser {
         self.consume(&TokenType::Set)?;
         let initializer = self.expr()?;
         Ok(Stmt::new(
-            Source::union(&start.get_source(), &initializer.source()),
+            Source::union(&start.source(), &initializer.source()),
             StmtType::Let {
                 name: Identifier::from(name),
                 var_type: RefCell::new(Rc::new(var_type)),
@@ -313,7 +305,7 @@ impl Parser {
         self.consume(&TokenType::ParenRight)?;
         let body = Rc::new(self.stmt()?);
         Ok(Stmt::new(
-            Source::union(&current.get_source(), &body.source()),
+            Source::union(&current.source(), &body.source()),
             StmtType::For {
                 initializer,
                 condition,
@@ -330,7 +322,7 @@ impl Parser {
         self.consume(&TokenType::ParenRight)?;
         let body = Rc::new(self.stmt()?);
         Ok(Stmt::new(
-            Source::union(&current.get_source(), &body.source()),
+            Source::union(&current.source(), &body.source()),
             StmtType::While { condition, body },
         ))
     }
@@ -343,14 +335,14 @@ impl Parser {
         let next = self.advance();
         let mut lhs = self.expr_lhs(next)?;
         while self.has_next() {
-            let op = self.peek().get_type();
+            let op = self.peek().token_type();
             if let Some(l_bp) = Parser::postfix_binding_power(op) {
                 // If current binding power is below minimum, we return the left hand side expression
                 if l_bp < min_bp {
                     break;
                 }
                 let next = self.advance();
-                match next.get_type() {
+                match next.token_type() {
                     TokenType::BracketLeft => {
                         lhs = self.expr_index(lhs)?;
                     }
@@ -378,7 +370,7 @@ impl Parser {
      * Parses the left hand side of a expression.
      */
     fn expr_lhs(&mut self, next: Token) -> Result<Expr> {
-        match next.get_type() {
+        match next.token_type() {
             TokenType::Bool(_) | TokenType::Number(_) | TokenType::String(_) => {
                 self.expr_literal(next)
             }
@@ -398,10 +390,10 @@ impl Parser {
     }
 
     fn expr_unary(&mut self, op: Token) -> Result<Expr> {
-        let r_bp = Parser::prefix_binding_power(op.get_type());
+        let r_bp = Parser::prefix_binding_power(op.token_type());
         let rhs = self.expr_bp(r_bp)?;
         Ok(Expr::new(
-            Source::union(&op.get_source(), &rhs.source()),
+            Source::union(&op.source(), &rhs.source()),
             ExprKind::Unary {
                 operator: op,
                 right: Rc::new(rhs),
@@ -411,13 +403,13 @@ impl Parser {
 
     fn expr_binary(&mut self, lhs: Expr, bp: u8) -> Result<Expr> {
         let next = self.advance();
-        if *next.get_type() == TokenType::Dot {
+        if *next.token_type() == TokenType::Dot {
             let rhs = self.advance();
-            if !rhs.get_type().is_identifer() {
+            if !rhs.token_type().is_identifer() {
                 return Err(parser_expected("expected an identidier on the RHS", rhs));
             }
             Ok(Expr::new(
-                Source::union(&lhs.source(), &rhs.get_source()),
+                Source::union(&lhs.source(), &rhs.source()),
                 ExprKind::Get {
                     left: Rc::new(lhs),
                     right: Identifier::from(rhs),
@@ -439,15 +431,15 @@ impl Parser {
 
     fn expr_call(&mut self, lhs: Expr) -> Result<Expr> {
         let mut arguments = Vec::new();
-        while *self.peek().get_type() != TokenType::ParenRight {
+        while *self.peek().token_type() != TokenType::ParenRight {
             arguments.push(Rc::new(self.expr()?));
-            if *self.peek().get_type() == TokenType::Comma {
+            if *self.peek().token_type() == TokenType::Comma {
                 self.consume(&TokenType::Comma)?;
             }
         }
         let rhs = self.consume(&TokenType::ParenRight)?;
         Ok(Expr::new(
-            Source::union(&lhs.source(), &rhs.get_source()),
+            Source::union(&lhs.source(), &rhs.source()),
             ExprKind::Call {
                 callee: Rc::new(lhs),
                 arguments,
@@ -457,7 +449,7 @@ impl Parser {
 
     fn expr_create_or_index(&mut self, next: Token) -> Result<Expr> {
         self.advance();
-        if *self.peek().get_type() == TokenType::BracketRight {
+        if *self.peek().token_type() == TokenType::BracketRight {
             // No index was given, only a array creation is possible
             self.advance();
             self.expr_create_array(next, None)
@@ -465,12 +457,12 @@ impl Parser {
             // A index was given, can be a sized array or
             let expr = Rc::new(self.expr()?);
             let current = self.consume(&TokenType::BracketRight)?;
-            if *self.peek().get_type() == TokenType::BraceLeft {
+            if *self.peek().token_type() == TokenType::BraceLeft {
                 self.expr_create_array(next, Some(expr))
             } else {
                 let kind = ExprKind::Index {
                     object: Rc::new(Expr::new(
-                        current.get_source(),
+                        current.source(),
                         ExprKind::Variable {
                             name: Identifier::from(next),
                             variable_type: RefCell::new(Rc::new(TypeDef::Unknown)),
@@ -479,7 +471,7 @@ impl Parser {
                     index: expr,
                     lookup: RefCell::new(Rc::new(TypeDef::Unknown)),
                 };
-                Ok(Expr::new(current.get_source(), kind))
+                Ok(Expr::new(current.source(), kind))
             }
         }
     }
@@ -491,16 +483,16 @@ impl Parser {
     ) -> Result<Expr> {
         self.consume(&TokenType::BraceLeft)?;
         let mut fields = Vec::new();
-        while *self.peek().get_type() != TokenType::BraceRight {
+        while *self.peek().token_type() != TokenType::BraceRight {
             fields.push(Rc::new(self.expr()?));
-            if *self.peek().get_type() != TokenType::BraceRight {
+            if *self.peek().token_type() != TokenType::BraceRight {
                 self.consume(&TokenType::Comma)?;
             }
         }
         let current = self.consume(&TokenType::BraceRight)?;
 
         Ok(Expr::new(
-            Source::union(&array_type.get_source(), &current.get_source()),
+            Source::union(&array_type.source(), &current.source()),
             ExprKind::CreateArray {
                 array_type: RefCell::new(Rc::new(TypeDef::Lazy(
                     array_type.identifier().to_string(),
@@ -527,9 +519,9 @@ impl Parser {
     fn expr_create_struct(&mut self, struct_name: Token) -> Result<Expr> {
         let current = self.consume(&TokenType::BraceLeft)?;
         let mut fields = Vec::new();
-        while *self.peek().get_type() != TokenType::BraceRight {
+        while *self.peek().token_type() != TokenType::BraceRight {
             let name = self.advance();
-            if !name.get_type().is_identifer() {
+            if !name.token_type().is_identifer() {
                 return Err(parser_expected(
                     "expected field name identifier for the struct",
                     name,
@@ -539,13 +531,13 @@ impl Parser {
             let expr = Rc::new(self.expr()?);
             let field = (Identifier::from(name), expr);
             fields.push(field);
-            if *self.peek().get_type() != TokenType::BraceRight {
+            if *self.peek().token_type() != TokenType::BraceRight {
                 self.consume(&TokenType::Comma)?;
             }
         }
         self.consume(&TokenType::BraceRight)?;
         Ok(Expr::new(
-            Source::union(&struct_name.get_source(), &current.get_source()),
+            Source::union(&struct_name.source(), &current.source()),
             ExprKind::CreateStruct {
                 struct_type: RefCell::new(Rc::new(TypeDef::Lazy(
                     struct_name.identifier().to_string(),
@@ -564,11 +556,11 @@ impl Parser {
     }
 
     fn expr_identifier(&mut self, next: Token) -> Result<Expr> {
-        match *self.peek().get_type() {
+        match *self.peek().token_type() {
             TokenType::BraceLeft => self.expr_create_struct(next),
             TokenType::BracketLeft => self.expr_create_or_index(next),
             _ => Ok(Expr::new(
-                next.get_source(),
+                next.source(),
                 ExprKind::Variable {
                     name: Identifier::from(next),
                     variable_type: RefCell::new(Rc::new(TypeDef::Unknown)),
@@ -582,13 +574,13 @@ impl Parser {
         let condition = Rc::new(self.expr()?);
         self.consume(&TokenType::ParenRight)?;
         let if_branch = Rc::new(self.stmt()?);
-        let (else_branch, source) = if *self.peek().get_type() == TokenType::Else {
+        let (else_branch, source) = if *self.peek().token_type() == TokenType::Else {
             self.consume(&TokenType::Else)?;
             let else_branch = self.stmt()?;
-            let source = Source::union(&current.get_source(), &else_branch.source());
+            let source = Source::union(&current.source(), &else_branch.source());
             (Some(Rc::new(else_branch)), source)
         } else {
-            let source = Source::union(&current.get_source(), &if_branch.source());
+            let source = Source::union(&current.source(), &if_branch.source());
             (None, source)
         };
         Ok(Expr::new(
@@ -603,12 +595,12 @@ impl Parser {
     }
 
     fn expr_literal(&mut self, next: Token) -> Result<Expr> {
-        Ok(Expr::new(next.get_source(), ExprKind::Literal(next)))
+        Ok(Expr::new(next.source(), ExprKind::Literal(next)))
     }
 
     fn expr_self(&mut self, next: Token) -> Result<Expr> {
         Ok(Expr::new(
-            next.get_source(),
+            next.source(),
             ExprKind::Variable {
                 name: Identifier::from(next),
                 variable_type: RefCell::new(Rc::new(TypeDef::Unknown)),
@@ -656,13 +648,13 @@ impl Parser {
 
     fn consume(&mut self, expected: &TokenType) -> Result<Token> {
         let next = self.advance();
-        if next.get_type() != expected {
+        if next.token_type() != expected {
             // The consumed token was not of the expected type
             return Err(crate::error::parser_expected(
                 format!(
                     "expected {:?} but found {:?}",
                     expected.clone(),
-                    next.get_type().clone()
+                    next.token_type().clone()
                 ),
                 next,
             ));

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -541,7 +541,7 @@ impl<'a> StmtVisitor<'a> for Resolution<'a> {
 impl<'a> DeclVisitor<'a> for Resolution<'a> {
     type Output = Result<()>;
 
-    fn visit_import(&mut self, _: &[Identifier]) -> Result<()> {
+    fn visit_import(&mut self, _: &[Identifier]) -> Self::Output {
         Ok(())
     }
 
@@ -550,7 +550,7 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         name: &'a Identifier,
         members: &'a [(Identifier, TypeCell)],
         methods: &'a [Rc<Decl>],
-    ) -> Result<()> {
+    ) -> Self::Output {
         self.begin_scope();
         let struct_type = self
             .types
@@ -571,14 +571,15 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         Ok(())
     }
 
-    fn visit_procedure(
+    fn visit_function(
         &mut self,
         identifier: &'a Identifier,
         return_type: &'a TypeCell,
         params: &'a [(Identifier, TypeCell)],
         body: &'a [Stmt],
         is_extern: bool,
-    ) -> Result<()> {
+        _: bool,
+    ) -> Self::Output {
         if self.return_type.is_some() {
             Err(Error::new(vec![Diagnostic::new(
                 "return type already exists before body was defined".to_string(),
@@ -634,7 +635,7 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         _: &'a Identifier,
         var_type: &'a TypeCell,
         initializer: &'a Expr,
-    ) -> Result<()> {
+    ) -> Self::Output {
         let ref_type = self.get_ref_type(var_type.borrow().clone())?;
         if !(ref_type.clone() == self.visit_expr(initializer).unwrap()) {
             Err(Error::new(vec![Diagnostic::new(

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -39,10 +39,6 @@ impl<'a> Resolution<'a> {
         Ok(self)
     }
 
-    pub fn analysed(self) -> Vec<Rc<RefCell<TypeNames>>> {
-        self.scopes
-    }
-
     fn declare_variable(&mut self, var_name: &Identifier, var_type: Rc<TypeDef>) -> Result<()> {
         if (*self
             .scopes
@@ -139,7 +135,9 @@ impl<'a> Resolution<'a> {
     }
 }
 
-impl<'a> ExprVisitor<'a, Result<Rc<TypeDef>>> for Resolution<'a> {
+impl<'a> ExprVisitor<'a> for Resolution<'a> {
+    type Output = Result<Rc<TypeDef>>;
+
     fn visit_unary(&mut self, operator: &Token, right: &'a Rc<Expr>) -> Result<Rc<TypeDef>> {
         let throw_error = |msg: &str| {
             Err(Error::new(vec![Diagnostic::new(
@@ -444,8 +442,10 @@ impl<'a> ExprVisitor<'a, Result<Rc<TypeDef>>> for Resolution<'a> {
     }
 }
 
-impl<'a> StmtVisitor<'a, Result<Option<Rc<TypeDef>>>> for Resolution<'a> {
-    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Result<Option<Rc<TypeDef>>> {
+impl<'a> StmtVisitor<'a> for Resolution<'a> {
+    type Output = Result<Option<Rc<TypeDef>>>;
+
+    fn visit_block(&mut self, statements: &'a [Rc<Stmt>]) -> Self::Output {
         let mut errors = Option::None;
         self.begin_scope();
         for stmt in statements {
@@ -471,7 +471,7 @@ impl<'a> StmtVisitor<'a, Result<Option<Rc<TypeDef>>>> for Resolution<'a> {
         name: &'a Identifier,
         var_type: &'a TypeCell,
         initializer: &'a Expr,
-    ) -> Result<Option<Rc<TypeDef>>> {
+    ) -> Self::Output {
         let mut real_type = self.visit_expr(initializer)?;
         if let TypeDef::Lazy(expected_type) = var_type.borrow().as_ref() {
             let ref_type = self.get_type(expected_type)?;
@@ -489,20 +489,16 @@ impl<'a> StmtVisitor<'a, Result<Option<Rc<TypeDef>>>> for Resolution<'a> {
         Ok(None)
     }
 
-    fn visit_return(&mut self, value: &'a Expr) -> Result<Option<Rc<TypeDef>>> {
+    fn visit_return(&mut self, value: &'a Expr) -> Self::Output {
         self.return_type = Some(self.visit_expr(value)?);
         Ok(None)
     }
 
-    fn visit_break(&mut self) -> Result<Option<Rc<TypeDef>>> {
+    fn visit_break(&mut self) -> Self::Output {
         Ok(None)
     }
 
-    fn visit_while(
-        &mut self,
-        condition: &'a Expr,
-        body: &'a Rc<Stmt>,
-    ) -> Result<Option<Rc<TypeDef>>> {
+    fn visit_while(&mut self, condition: &'a Expr, body: &'a Rc<Stmt>) -> Self::Output {
         self.begin_scope();
         if !self.visit_expr(condition)?.is_bool() {
             Err(Error::new(vec![Diagnostic::new(
@@ -521,7 +517,7 @@ impl<'a> StmtVisitor<'a, Result<Option<Rc<TypeDef>>>> for Resolution<'a> {
         condition: &'a Expr,
         increment: &'a Expr,
         body: &'a Rc<Stmt>,
-    ) -> Result<Option<Rc<TypeDef>>> {
+    ) -> Self::Output {
         self.begin_scope();
         self.visit_stmt(initializer)?;
         if !self.visit_expr(condition)?.is_bool() {
@@ -537,12 +533,14 @@ impl<'a> StmtVisitor<'a, Result<Option<Rc<TypeDef>>>> for Resolution<'a> {
         Ok(None)
     }
 
-    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Result<Option<Rc<TypeDef>>> {
+    fn visit_expr_stmt(&mut self, expr: &'a Expr) -> Self::Output {
         Ok(Some(self.visit_expr(expr)?))
     }
 }
 
-impl<'a> DeclVisitor<'a, Result<()>> for Resolution<'a> {
+impl<'a> DeclVisitor<'a> for Resolution<'a> {
+    type Output = Result<()>;
+
     fn visit_import(&mut self, _: &[Identifier]) -> Result<()> {
         Ok(())
     }
@@ -573,7 +571,7 @@ impl<'a> DeclVisitor<'a, Result<()>> for Resolution<'a> {
         Ok(())
     }
 
-    fn visit_function(
+    fn visit_procedure(
         &mut self,
         identifier: &'a Identifier,
         return_type: &'a TypeCell,

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -49,8 +49,8 @@ impl<'a> Resolution<'a> {
         .is_some()
         {
             return Err(Error::new(vec![Diagnostic::new(
-                format!("variable '{}' was already declared", var_name.get_name()),
-                var_name.get_source(),
+                format!("variable '{}' was already declared", var_name.name()),
+                var_name.source(),
             )]));
         }
         Ok(())
@@ -58,7 +58,7 @@ impl<'a> Resolution<'a> {
 
     fn lookup_variable(&mut self, var_name: &Identifier) -> Result<Rc<TypeDef>> {
         if let Some(scope) = self.scopes.last() {
-            if let Some(v) = scope.borrow().get(var_name.get_name()) {
+            if let Some(v) = scope.borrow().get(var_name.name()) {
                 Ok(v.clone())
             } else {
                 let origin = self.scopes.pop().expect("expected scope");
@@ -68,59 +68,47 @@ impl<'a> Resolution<'a> {
             }
         } else {
             Err(Error::new(vec![Diagnostic::new(
-                format!("could not find variable '{}'", var_name.get_name()),
-                var_name.get_source(),
+                format!("could not find variable '{}'", var_name.name()),
+                var_name.source(),
             )]))
         }
     }
 
-    fn get_type(&self, name: &str) -> Result<Rc<TypeDef>> {
-        let ref_type: Rc<TypeDef> = self
-            .types
-            .get(name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "expected type name does not exist '{}' in {:#?}",
-                    name, self
-                )
-            })
-            .clone();
-        self.get_ref_type(ref_type)
+    /// Find this type by name inside the types map.
+    fn find_type(&self, name: &str) -> Result<Rc<TypeDef>> {
+        let ref_type = self.types.get(name).expect(&format!(
+            "expected type name does not exist '{}' in {:#?}",
+            name, self
+        ));
+        self.ref_type(ref_type.clone())
     }
 
-    fn get_ref_type(&self, ref_type: Rc<TypeDef>) -> Result<Rc<TypeDef>> {
+    /// Get the underlying type of the type. If the type is only known by its name, it will try to find its definition.
+    fn ref_type(&self, ref_type: Rc<TypeDef>) -> Result<Rc<TypeDef>> {
         if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
-            self.get_type(lazy_name)
+            self.find_type(lazy_name)
         } else {
             Ok(ref_type)
         }
     }
 
-    fn get_member(&self, lookup: Rc<TypeDef>, member_name: &'a Identifier) -> Result<Rc<TypeDef>> {
+    fn member(&self, lookup: Rc<TypeDef>, member_name: &'a Identifier) -> Result<Rc<TypeDef>> {
         if let TypeDef::Struct { name: _, members } = lookup.as_ref() {
             let ref_type: Rc<TypeDef> = members
-                .get(member_name.get_name())
+                .get(member_name.name())
                 .expect("expected struct contains field")
                 .clone();
-            if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
-                self.get_type(lazy_name)
-            } else {
-                Ok(ref_type)
-            }
+            self.ref_type(ref_type)
         } else if let TypeDef::Module { types: _, fields } = lookup.as_ref() {
             let ref_type = fields
-                .get(member_name.get_name())
+                .get(member_name.name())
                 .expect("expected modue contains field")
                 .clone();
-            if let TypeDef::Lazy(lazy_name) = ref_type.as_ref() {
-                self.get_type(lazy_name)
-            } else {
-                Ok(ref_type)
-            }
+            self.ref_type(ref_type)
         } else {
             Err(Error::new(vec![Diagnostic::new(
                 "expected struct".to_string(),
-                member_name.get_source(),
+                member_name.source(),
             )]))
         }
     }
@@ -142,11 +130,11 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
         let throw_error = |msg: &str| {
             Err(Error::new(vec![Diagnostic::new(
                 msg.to_string(),
-                Source::union(&operator.get_source(), &right.source()),
+                Source::union(&operator.source(), &right.source()),
             )]))
         };
         let r = self.visit_expr(right)?;
-        match operator.get_type() {
+        match operator.token_type() {
             TokenType::Not => {
                 if !r.is_bool() {
                     throw_error("the value is not a boolean and cannot be negated")?;
@@ -177,7 +165,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
         };
         let l = self.visit_expr(left)?;
         let r = self.visit_expr(right)?;
-        match operator.get_type() {
+        match operator.token_type() {
             TokenType::Add
             | TokenType::Sub
             | TokenType::Mul
@@ -210,12 +198,12 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
             }
             TokenType::Leq | TokenType::Low | TokenType::Geq | TokenType::Gre => {
                 if !l.is_number() {
-                    throw_error("the left-hand-side is expected to be a number")?;
+                    return throw_error("the left-hand-side is expected to be a number");
                 }
                 if !r.is_number() {
-                    throw_error("the right-hand-side is expected to be a number")?;
+                    return throw_error("the right-hand-side is expected to be a number");
                 }
-                self.get_type("bool")
+                self.find_type("bool")
             }
             TokenType::Eq | TokenType::Neq => match (l.is_number(), r.is_number()) {
                 (true, true) => Ok(l),
@@ -251,7 +239,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
     ) -> Result<Rc<TypeDef>> {
         let l = self.visit_expr(left)?;
         *lookup.borrow_mut() = l.clone();
-        self.get_member(l, right)
+        self.member(l, right)
     }
 
     fn visit_index(
@@ -269,7 +257,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
                     index.source(),
                 )]))?;
             }
-            let ref_type = self.get_ref_type(array_type.clone())?;
+            let ref_type = self.ref_type(array_type.clone())?;
             *looup.borrow_mut() = ref_type.clone();
             Ok(ref_type)
         } else {
@@ -293,7 +281,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
         {
             for (argument, para_type) in arguments.iter().zip(parameters) {
                 let arg_type = self.visit_expr(argument)?;
-                if !arg_type.is_castable_to(&*self.get_ref_type(para_type.clone())?) {
+                if !arg_type.is_castable_to(&*self.ref_type(para_type.clone())?) {
                     Err(Error::new(vec![Diagnostic::new(
                         format!(
                             "argument type '{}' supplied to function does not match parameter type '{}'",
@@ -303,7 +291,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
                     )]))?;
                 }
             }
-            self.get_ref_type(return_type.clone())
+            self.ref_type(return_type.clone())
         } else {
             Err(Error::new(vec![Diagnostic::new(
                 "expected call a function".to_string(),
@@ -326,7 +314,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
                 )]))?;
             }
         }
-        let ref_type = self.get_ref_type(array_type.borrow().clone())?;
+        let ref_type = self.ref_type(array_type.borrow().clone())?;
         *array_type.borrow_mut() = ref_type.clone();
 
         for field in fields {
@@ -346,11 +334,11 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
         struct_type: &'a TypeCell,
         fields: &'a [(Identifier, Rc<Expr>)],
     ) -> Result<Rc<TypeDef>> {
-        let ref_type = self.get_ref_type(struct_type.borrow().clone())?;
+        let ref_type = self.ref_type(struct_type.borrow().clone())?;
 
         for (field_name, field_expr) in fields {
             let field_type = self.visit_expr(field_expr)?;
-            if !field_type.is_castable_to(&*self.get_member(ref_type.clone(), field_name)?) {
+            if !field_type.is_castable_to(&*self.member(ref_type.clone(), field_name)?) {
                 Err(Error::new(vec![Diagnostic::new(
                     "expected size of array to be an integer".to_string(),
                     field_expr.source(),
@@ -421,7 +409,7 @@ impl<'a> ExprVisitor<'a> for Resolution<'a> {
     fn visit_literal(&mut self, value: &Token) -> Result<Rc<TypeDef>> {
         Ok(self
             .types
-            .get(match value.get_type() {
+            .get(match value.token_type() {
                 TokenType::Number(_) => "i32",
                 TokenType::String(_) => "str",
                 TokenType::Bool(_) => "bool",
@@ -474,13 +462,13 @@ impl<'a> StmtVisitor<'a> for Resolution<'a> {
     ) -> Self::Output {
         let mut real_type = self.visit_expr(initializer)?;
         if let TypeDef::Lazy(expected_type) = var_type.borrow().as_ref() {
-            let ref_type = self.get_type(expected_type)?;
+            let ref_type = self.find_type(expected_type)?;
             if real_type.is_castable_to(&ref_type) {
                 real_type = ref_type;
             } else {
                 Err(Error::new(vec![Diagnostic::new(
                     "assiged a value that does not have the declared type".to_string(),
-                    name.get_source(),
+                    name.source(),
                 )]))?;
             }
         }
@@ -554,14 +542,14 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         self.begin_scope();
         let struct_type = self
             .types
-            .get(name.get_name())
+            .get(name.name())
             .expect("expected to find own struct name when trying to reference self")
             .clone();
         (*self.scopes.last_mut().expect("expected scope"))
             .borrow_mut()
             .insert("self".to_string(), struct_type);
         for (_, member_type) in members {
-            let ref_type = self.get_ref_type(member_type.borrow().clone())?;
+            let ref_type = self.ref_type(member_type.borrow().clone())?;
             *member_type.borrow_mut() = ref_type;
         }
         for method in methods {
@@ -583,16 +571,16 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         if self.return_type.is_some() {
             Err(Error::new(vec![Diagnostic::new(
                 "return type already exists before body was defined".to_string(),
-                identifier.get_source(),
+                identifier.source(),
             )]))?;
         }
-        let ref_type = self.get_ref_type(return_type.borrow().clone())?;
+        let ref_type = self.ref_type(return_type.borrow().clone())?;
         *return_type.borrow_mut() = ref_type.clone();
 
         // When a new body begins, first define all parameters as local variables.
         self.begin_scope();
         for (param_name, param_type) in params {
-            let ref_type = self.get_ref_type(param_type.borrow().clone())?;
+            let ref_type = self.ref_type(param_type.borrow().clone())?;
             self.declare_variable(param_name, ref_type.clone())?;
             *param_type.borrow_mut() = ref_type;
         }
@@ -614,15 +602,15 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         }
 
         // Calculate what was declared as a return type and what we really got.
-        let real = self.get_ref_type(
+        let real = self.ref_type(
             self.return_type
                 .clone()
-                .unwrap_or_else(|| self.get_type("void").unwrap()),
+                .unwrap_or_else(|| self.find_type("void").unwrap()),
         )?;
         if !real.is_castable_to(ref_type.as_ref()) {
             Err(Error::new(vec![Diagnostic::new(
                 format!("could not cast {}", real),
-                identifier.get_source(),
+                identifier.source(),
             )]))?;
         }
         self.return_type = None;
@@ -636,7 +624,7 @@ impl<'a> DeclVisitor<'a> for Resolution<'a> {
         var_type: &'a TypeCell,
         initializer: &'a Expr,
     ) -> Self::Output {
-        let ref_type = self.get_ref_type(var_type.borrow().clone())?;
+        let ref_type = self.ref_type(var_type.borrow().clone())?;
         if !(ref_type.clone() == self.visit_expr(initializer).unwrap()) {
             Err(Error::new(vec![Diagnostic::new(
                 "const does not have the declared type".to_string(),

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -156,7 +156,7 @@ impl Display for TypeDef {
                 types: _,
                 fields: _,
             } => formatter.write_str("<module>"),
-            Self::Struct { name, members: _ } => formatter.write_str(name.get_name()),
+            Self::Struct { name, members: _ } => formatter.write_str(name.name()),
             Self::Function {
                 parameters,
                 return_type,


### PR DESCRIPTION
**Changes made**
I added procedures and split `fn` to `func` and `proc`. Additionally, the Token `To` was introduced to represent the left arrow (->), which is now used for specifying return types. Besides that, this pr contains two minor fixes. The first one is a small bug fix that prevents ignoring every second input file inside the cli. The other is a feature for all Visitor traits to use associated types.

**Related issues**
This pr implements some features of #16. It is just the first one of many. I decided to split the changes into multiple smaller bug fixes because I think that this way it will be easier to review and understand what was changed.

**Checklist**

- Build on platform:
  - [ ] Windows 10/11
  - [x] Linux (NixOS)
  - [ ] macOS
- [x] Tested all changes (run `cargo test`)
- [x] Formatted all files (run `cargo fmt`)
- [x] Fits [CONTRIBUTING.md](https://github.com/tau-lang/tau/blob/master/CONTRIBUTING.md)
- [x] Fits [CODE_OF_CONDUCT.md](https://github.com/tau-lang/tau/blob/main/CODE_OF_CONDUCT.md)
